### PR TITLE
Add UTF-8 string serialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `?_`          | Optional nested serializable object (`_` is literal) | 1 byte presence flag + serialized nested object if present | `field(metadata={"format": "?_", "ptype": MyClass})` |
 | `[_]`         | Array of nested serializable objects (`_` is literal) | 4-byte length prefix + serialized nested objects in sequence | `field(metadata={"format": "[_]", "ptype": MyClass})` |
 | `[?_]`        | Array of optional nested objects (`_` is literal) | 4-byte length + presence bitmap + serialized present objects | `field(metadata={"format": "[?_]", "ptype": MyClass})` |
+| `S`           | UTF-8 string with length prefix                | 4-byte length prefix + UTF-8 bytes           | `field(metadata={"format": "S"})` |
+| `S[x]`        | Fixed-length UTF-8 string of `x` bytes          | UTF-8 bytes padded/truncated to `x` bytes    | `field(metadata={"format": "S[8]"})` |
 | `E<x>`        | Enum stored as integer type `x` (`b`, `B`, `h`, `H`, `i`, `I`) | Integer representing the Enum value using chosen size | `field(metadata={"format": "E<B>", "ptype": MyEnum})` |
 | `T<x>`        | Fixed-length tuple of basic types            | Raw binary data for each tuple element           | `field(metadata={"format": "T<If>"})` |
 


### PR DESCRIPTION
## feat(serialization): add support for string serialization formats S (variable-length) and S[x] (fixed-length) (#N)

### Summary

- Adds support for `S` format for variable-length UTF-8 strings.  
  Serializes as 4-byte length prefix (unsigned int, little-endian), followed by UTF-8 encoded bytes.

- Adds support for `S[x]` format for fixed-length UTF-8 strings.  
  Serializes as exactly `x` bytes, padded with ASCII spaces if the string is shorter.  
  **If the string is too long to fit, it is truncated so that the UTF-8 encoding fits within `x` bytes, without breaking multi-byte Unicode codepoints.**

- On deserialization, the bytes are decoded as UTF-8 (errors are handled strictly; invalid sequences will raise an error).

### Usage Example

```python 
@dataclass
class Demo:
    name: str = field(metadata={"format": "S"})
    tag: str = field(metadata={"format": "S[8]"})

d = Demo(name="Name", tag="Tag")
``` 

### Notes

- **Truncation always preserves Unicode integrity:** No codepoint is split between bytes.
- Only valid UTF-8 is accepted; decoding errors will raise an exception.
- Padding (for `S[x]`) uses the ASCII space character (U+0020).

Update README to document these two new format strings, and add tests including edge cases.

