### PR TITLE
feat(validation): restrict struct format chars

### DIFF
--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -265,9 +265,12 @@ def test_super_combo():
     ("[_]", None, "Type must be provided for generic array"),
     ("[?_]", None, "Type must be provided for optional array"),
 
+    ("[x]", None, "Struct only supports format characters BHILQbdefhilq"),
+
     ("?",   None, "Struct format for optional type invalid"),
     ("?__", None, "Struct format for optional type invalid"),
     ("?_",  None, "Type must be provided for generic optional"),
+    ("?x", None, "Struct only supports format characters BHILQbdefhilq"),
 
     ("E<",  None, "Struct format for enum type invalid"),
     ("E<>",  None, "Struct format for enum type invalid"),
@@ -278,6 +281,7 @@ def test_super_combo():
     ("T<",   None, "Struct format for tuple type invalid"),
     ("T<>",  None, "Struct format for tuple type invalid"),
     ("T<__>", None, "Struct format for tuple type invalid"),
+    ("T<x>", None, "Struct only supports format characters BHILQbdefhilq"),
 
     ("S[", None, "Struct format for string type invalid"),
     ("S[]", None, "Struct format for string type invalid"),


### PR DESCRIPTION
## feat(validation): enforce allowed struct format characters in custom serialization

### Description 

This PR adds a verification step to ensure that all **format strings** used in:

- **Single values**: e.g., `x` 
- **Fixed-length arrays**: e.g., `[x]` 
- **Optional fields**: e.g., `?x` 
- **Tuples**: e.g., `T[xxx]` 

are composed **only of supported `struct` format characters**. 

Add the verification logic at parse-time.

Include **unit tests** to cover:
  - Arrays with invalid format characters.
  - Optionals with invalid format characters.
  - Tuples with invalid format characters.

### Allowed Format Characters

| Category    | Supported Formats   |
|-------------|---------------------|
| **Integers** | `b B h H i I l L q Q` | 
| **Floats**   | `e f d`              | 

### Enforcement 

For any field using:

- A **single format character** (e.g., `I`, `f`, etc.)
- An **array**: `[x]`
- An **optional**: `?x`
- A **tuple**: `T[xxx]`

We must verify that:

✅ **Each character in `x` or `xxx` belongs to the allowed set:**

```
b B h H i I l L q Q e f d
```

### Rationale

- Prevents accidental use of unsupported `struct` formats (e.g., `c`, `s`, `p`, `n`, etc.).
- Ensures serialization logic is consistent and predictable.
- Enables **fail-fast validation** when an invalid format is specified.
- Force using **only fixed-length format strings**, avoiding variable-sized encodings or ambiguous layouts.