### PR TITLE
Add optional string serialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `[np:x]`   | **NumPy array**                      | 1-byte ndim + N×4-byte shape + raw data buffer                         | `x` must be NumPy dtype: `u8`, `u16`, `u32`, `i8`, `i16`, `i32`, `f32`, `f64` |
 | `S`        | **Variable-length UTF-8 string**     | 4-byte length prefix + UTF-8 encoded bytes                             | -                                                                     |
 | `S[x]`     | **Fixed-length UTF-8 string**        | UTF-8 encoded, space-padded or truncated to `x` bytes (UTF-8 safe)     | -                                                                     |
+| `?S`       | **Optional variable-length UTF-8 string** | 1-byte presence flag + 4-byte length + UTF-8 encoded bytes            | -
+| `?S[x]`    | **Optional fixed-length UTF-8 string**    | 1-byte presence flag + UTF-8 encoded, space-padded or truncated to `x` bytes | -
 | `E<x>`     | **Enum stored as integer**           | Stored as `x` (e.g., `B`, `H`, `I`)                                    | `x` must be one of: `b B h H i I`                                     |
 | `?_`       | **Optional nested object**           | 1-byte presence flag + nested serialization if present                 | -                                                                     |
 | `[_]`      | **Array of nested objects**          | 4-byte length prefix + consecutive nested serializations               | -                                                                     |

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -154,6 +154,19 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
                 )
             return FieldSpecCompiledArray(name, element_type)
 
+        if struct_format.startswith("?S["):
+            if not struct_format.endswith("]"):
+                raise ValueError("Invalid format: fixed-length string must end with ']'")
+            length_txt = struct_format[3:-1]
+            if not length_txt.isdigit():
+                raise ValueError(
+                    "Invalid format: fixed-length string must contain a numeric length"
+                )
+            return FieldSpecCompiledOptionalFixedString(name, int(length_txt))
+
+        if struct_format == "?S":
+            return FieldSpecCompiledOptionalString(name)
+
         if struct_format[0] == "?":
             if not len(struct_format) == 2:
                 raise ValueError("Invalid format: optional format must be two characters")
@@ -1250,6 +1263,86 @@ class FieldSpecCompiledFixedString(FieldSpecCompiled):
                 The fixed byte size for serialization (`self.length`).
         """
         return self.length
+
+
+class FieldSpecCompiledOptionalString(FieldSpecCompiled):
+    """Optional variable-length UTF-8 string with presence flag."""
+
+    def serialize_to_bytes(self, class_obj: Any, buffer: bytearray, idx: int) -> int:
+        value = getattr(class_obj, self.name)
+        if value is None:
+            struct.pack_into("<b", buffer, idx, 0)
+            return idx + 1
+        struct.pack_into("<b", buffer, idx, 1)
+        idx += 1
+        data = value.encode("utf-8")
+        struct.pack_into("<I", buffer, idx, len(data))
+        idx += 4
+        buffer[idx:idx + len(data)] = data
+        return idx + len(data)
+
+    def deserialize_from_bytes(self, buffer: bytearray, idx: int) -> Tuple[Any, int]:
+        present = struct.unpack_from("<b", buffer, idx)[0]
+        idx += 1
+        if not present:
+            return None, idx
+        length = struct.unpack_from("<I", buffer, idx)[0]
+        idx += 4
+        data = bytes(buffer[idx:idx + length])
+        return data.decode("utf-8"), idx + length
+
+    def serialized_byte_size(self, class_obj: Any) -> int:
+        value = getattr(class_obj, self.name)
+        if value is None:
+            return 1
+        return 1 + 4 + len(value.encode("utf-8"))
+
+
+class FieldSpecCompiledOptionalFixedString(FieldSpecCompiled):
+    """Optional fixed-length UTF-8 string with presence flag."""
+
+    length: int
+
+    def __init__(self, name: str, length: int):
+        super().__init__(name)
+        self.length = length
+
+    def serialize_to_bytes(self, class_obj: Any, buffer: bytearray, idx: int) -> int:
+        value = getattr(class_obj, self.name)
+        if value is None:
+            struct.pack_into("<b", buffer, idx, 0)
+            return idx + 1
+        struct.pack_into("<b", buffer, idx, 1)
+        idx += 1
+        data = value.encode("utf-8")
+        if len(data) > self.length:
+            trunc = data[: self.length]
+            while True:
+                try:
+                    trunc.decode("utf-8")
+                    data = trunc
+                    break
+                except UnicodeDecodeError as exc:
+                    trunc = trunc[: exc.start]
+        buffer[idx:idx + len(data)] = data
+        if len(data) < self.length:
+            buffer[idx + len(data):idx + self.length] = b" " * (self.length - len(data))
+        return idx + self.length
+
+    def deserialize_from_bytes(self, buffer: bytearray, idx: int) -> Tuple[Any, int]:
+        present = struct.unpack_from("<b", buffer, idx)[0]
+        idx += 1
+        if not present:
+            return None, idx
+        data = bytes(buffer[idx:idx + self.length])
+        s = data.rstrip(b" ").decode("utf-8")
+        return s, idx + self.length
+
+    def serialized_byte_size(self, class_obj: Any) -> int:
+        value = getattr(class_obj, self.name)
+        if value is None:
+            return 1
+        return 1 + self.length
 
 
 class FieldSpecCompiledTuple(FieldSpecCompiled):

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -372,6 +372,10 @@ def test_super_combo():
     ("S[]", None, "Invalid format: fixed-length string must contain a numeric length"),
     ("S[a]", None, "Invalid format: fixed-length string must contain a numeric length"),
 
+    ("?S[", None, "Invalid format: fixed-length string must end with ']'"),
+    ("?S[]", None, "Invalid format: fixed-length string must contain a numeric length"),
+    ("?S[a]", None, "Invalid format: fixed-length string must contain a numeric length"),
+
     ("[np:bad]", None, "Unsupported numpy dtype"),
     ("[np:u8", None, "Invalid format: numpy array format string must end with ']'"),
 
@@ -468,6 +472,18 @@ class TestStringFixed(FifoSerializable):
     tag: str = field(metadata={"format": "S[8]"})
 
 
+@serializable
+@dataclass
+class TestOptionalStringVar(FifoSerializable):
+    name: str | None = field(metadata={"format": "?S"})
+
+
+@serializable
+@dataclass
+class TestOptionalStringFixed(FifoSerializable):
+    tag: str | None = field(metadata={"format": "?S[8]"})
+
+
 def test_string_variable_roundtrip() -> None:
     obj = TestStringVar("hello\u03c0")
     buf = bytearray(obj.serialized_byte_size())
@@ -532,3 +548,33 @@ def test_string_fixed_emoji_truncation_no_length_hack() -> None:
     restored, _ = TestStringFixed.deserialize_from_bytes(buf, 0)
     # After deserialization, only "..🚀" should remain
     assert restored.tag == "..🚀"
+
+
+def test_optional_string_variable_roundtrip() -> None:
+    obj = TestOptionalStringVar("hello")
+    buf = bytearray(obj.serialized_byte_size())
+    obj.serialize_to_bytes(buf, 0)
+    restored, _ = TestOptionalStringVar.deserialize_from_bytes(buf, 0)
+    assert restored.name == "hello"
+
+    obj_none = TestOptionalStringVar(None)
+    buf2 = bytearray(obj_none.serialized_byte_size())
+    obj_none.serialize_to_bytes(buf2, 0)
+    restored_none, _ = TestOptionalStringVar.deserialize_from_bytes(buf2, 0)
+    assert restored_none.name is None
+
+
+def test_optional_string_fixed_roundtrip() -> None:
+    obj = TestOptionalStringFixed("hi")
+    buf = bytearray(obj.serialized_byte_size())
+    obj.serialize_to_bytes(buf, 0)
+    assert buf[0] == 1
+    restored, _ = TestOptionalStringFixed.deserialize_from_bytes(buf, 0)
+    assert restored.tag == "hi"
+
+    obj_none = TestOptionalStringFixed(None)
+    buf2 = bytearray(obj_none.serialized_byte_size())
+    obj_none.serialize_to_bytes(buf2, 0)
+    assert buf2 == b"\x00"
+    restored_none, _ = TestOptionalStringFixed.deserialize_from_bytes(buf2, 0)
+    assert restored_none.tag is None


### PR DESCRIPTION
## Feature: Support Optional Strings in Serialization Module

### Summary

Add support for optional strings in the serialization module.

- `"?S"` represents an optional variable-length string. 
- `"?S[x]"` represents an optional fixed-length string. 

### Tasks

- [x] Implement support for `?S` and `?S[x]` formats in the serialization logic.
- [x] Update test cases to include:
  - Positive tests for serializing and deserializing `None` and valid string values.
  - Negative tests for invalid values and incorrect format usage.
- [x] Update the README to document the new `?S` and `?S[x]` formats.

### Testing

- `pytest -q`