### PR TITLE
feat: support per-field custom serialization callables

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,11 @@ sock_client.close()
 
 Provides a lightweight, efficient binary serialization framework for Python dataclasses.
 
-- `@serializable`: Decorator to enable serialization/deserialization on dataclasses.  
+- `@serializable`: Decorator to enable serialization/deserialization on dataclasses.
 - Supports scalar types, enums, optional fields, arrays, and fixed-length tuples.
-- Uses dataclass `field` metadata (e.g., `format`, `ptype`) for flexible, extensible field definitions.  
-- Designed for preallocated buffers to maximize performance and minimize allocations.  
+- Uses dataclass `field` metadata (e.g., `format`, `ptype`) for flexible, extensible field definitions.
+- Custom per-field (de)serialization via `field` metadata callables (`serialize`, `deserialize`, `bytelength`).
+- Designed for preallocated buffers to maximize performance and minimize allocations.
 - Works well with microcontroller and embedded system data formats as it is a compact binary format prioritizing direct raw serialization with very little overhead.
 
 **Supported Format Strings:**
@@ -385,6 +386,26 @@ Provides a lightweight, efficient binary serialization framework for Python data
 
 **Note:** Primitive format codes `b B h H i I l L q Q e f d` follow the [Python `struct` module](https://docs.python.org/3/library/struct.html).  
 `y` is a special format for booleans, serialized as a single byte (`0` for `False`, `1` for `True`).
+
+### Custom per-field serialization
+
+Fields can provide `serialize`, `deserialize`, and `bytelength` callables in their
+`field` metadata. When present, these functions are used instead of a `format` or
+`ptype`, enabling custom types without any global registry. The helper
+`field_UUID()` demonstrates serializing a `uuid.UUID` using this mechanism:
+
+```python
+import uuid
+from dataclasses import dataclass
+from fifo_dev_common.serialization.fifo_serialization import (
+    FifoSerializable, serializable, field_UUID,
+)
+
+@serializable
+@dataclass
+class MyEvent(FifoSerializable):
+    correlation_id: uuid.UUID = field_UUID()
+```
 
 **Examples:**
 

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 from abc import ABC
 import abc
-from dataclasses import Field, fields
+from dataclasses import Field, field, fields
 from enum import Enum
 import struct
 from typing import Any, Self, Tuple, Type, TypeVar
+import uuid
 import numpy as np
 from numpy.typing import NDArray
 from fifo_dev_common.socket.socket_utils import SupportsRecvInto, SupportsSendAll, recv_all
@@ -24,6 +25,35 @@ _NUMPY_DTYPES: dict[str, np.dtype[Any]] = {
 _ALLOWED_STRUCT_FORMAT_CHARS = {
     "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "e", "f", "d", "y",
 }
+
+
+def field_UUID(**kwargs: Any) -> Field[uuid.UUID]:
+    """Return a :func:`dataclasses.field` configured for :class:`uuid.UUID` values.
+
+    The returned field uses per-field custom serialization metadata to encode a
+    UUID directly as its 16 raw bytes without requiring a global registry or
+    wrapper class.
+    """
+
+    def _serialize(obj: uuid.UUID, buffer: bytearray, idx: int) -> int:
+        buffer[idx : idx + 16] = obj.bytes
+        return idx + 16
+
+    def _deserialize(buffer: bytearray, idx: int) -> tuple[uuid.UUID, int]:
+        return uuid.UUID(bytes=bytes(buffer[idx : idx + 16])), idx + 16
+
+    def _bytelength(_: uuid.UUID) -> int:
+        return 16
+
+    return field(
+        metadata={
+            "serialize": _serialize,
+            "deserialize": _deserialize,
+            "bytelength": _bytelength,
+        },
+        **kwargs,
+    )
+
 
 def compile_field(field: Field[Any]) -> FieldSpecCompiled:
     """
@@ -109,7 +139,23 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
 
     struct_format = field.metadata.get("format")
     ptype = field.metadata.get("ptype")
+    serialize_fn = field.metadata.get("serialize")
+    deserialize_fn = field.metadata.get("deserialize")
+    bytelength_fn = field.metadata.get("bytelength")
     name = field.name
+
+    if any(x is not None for x in (serialize_fn, deserialize_fn, bytelength_fn)):
+        if struct_format is not None or ptype is not None:
+            raise ValueError("Cannot specify 'format' or 'ptype' with custom serialization callables")
+        if not (
+            callable(serialize_fn)
+            and callable(deserialize_fn)
+            and callable(bytelength_fn)
+        ):
+            raise ValueError(
+                "Custom field requires callable 'serialize', 'deserialize', and 'bytelength'"
+            )
+        return FieldSpecCompiledCustom(name, serialize_fn, deserialize_fn, bytelength_fn)
 
     if struct_format is not None:
         if struct_format[0] == "[":
@@ -333,6 +379,33 @@ class FieldSpecCompiled(ABC):
             int:
                 The byte size needed for serialization of this field.
         """
+
+
+class FieldSpecCompiledCustom(FieldSpecCompiled):
+    """Field handler that delegates to custom callables supplied via metadata."""
+
+    def __init__(
+        self,
+        name: str,
+        serialize_fn: Any,
+        deserialize_fn: Any,
+        bytelength_fn: Any,
+    ) -> None:
+        super().__init__(name)
+        self._serialize_fn = serialize_fn
+        self._deserialize_fn = deserialize_fn
+        self._bytelength_fn = bytelength_fn
+
+    def serialize_to_bytes(self, class_obj: Any, buffer: bytearray, idx: int) -> int:
+        value = getattr(class_obj, self.name)
+        return self._serialize_fn(value, buffer, idx)
+
+    def deserialize_from_bytes(self, buffer: bytearray, idx: int) -> Tuple[Any, int]:
+        return self._deserialize_fn(buffer, idx)
+
+    def serialized_byte_size(self, class_obj: Any) -> int:
+        value = getattr(class_obj, self.name)
+        return self._bytelength_fn(value)
 
 
 class FieldSpecCompiledBasic(FieldSpecCompiled):
@@ -2137,9 +2210,11 @@ def serializable(cls: C) -> C:
     """
     compiled_fields: list[FieldSpecCompiled] = []
     for f in fields(cls):
-        # Only serialize fields with 'format' or 'ptype' in metadata
+        # Only serialize fields with serialization-related metadata
         meta = getattr(f, "metadata", None)
-        if meta and ("format" in meta or "ptype" in meta):
+        if meta and any(
+            k in meta for k in ("format", "ptype", "serialize", "deserialize", "bytelength")
+        ):
             compiled_fields.append(compile_field(f))
 
     setattr(cls, "_fifo_compiled_fields", compiled_fields)

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -8,7 +8,13 @@ import math
 import struct
 import numpy as np
 from numpy.typing import NDArray
-from fifo_dev_common.serialization.fifo_serialization import FifoSerializable, serializable, compile_field
+import uuid
+from fifo_dev_common.serialization.fifo_serialization import (
+    FifoSerializable,
+    serializable,
+    compile_field,
+    field_UUID,
+)
 
 
 def floats_equal_list(list1: list[float],
@@ -578,3 +584,45 @@ def test_optional_string_fixed_roundtrip() -> None:
     assert buf2 == b"\x00"
     restored_none, _ = TestOptionalStringFixed.deserialize_from_bytes(buf2, 0)
     assert restored_none.tag is None
+
+
+@serializable
+@dataclass
+class TestUUID(FifoSerializable):
+    uid: uuid.UUID = field_UUID()
+
+
+def test_custom_uuid_roundtrip() -> None:
+    val = uuid.uuid4()
+    obj = TestUUID(val)
+    buf = bytearray(obj.serialized_byte_size())
+    obj.serialize_to_bytes(buf, 0)
+    restored, _ = TestUUID.deserialize_from_bytes(buf, 0)
+    assert restored.uid == val
+
+
+def test_compile_field_custom_errors() -> None:
+    ser = lambda v, b, i: i
+    # Missing deserialize
+    mock_field1 = SimpleNamespace(
+        name="x", metadata={"serialize": ser, "bytelength": lambda _v: 0}
+    )
+    with pytest.raises(
+        ValueError, match="Custom field requires callable 'serialize', 'deserialize', and 'bytelength'"
+    ):
+        compile_field(mock_field1)  # type: ignore[arg-type]
+
+    # Mixing with format
+    mock_field2 = SimpleNamespace(
+        name="x",
+        metadata={
+            "format": "I",
+            "serialize": ser,
+            "deserialize": lambda b, i: (0, i),
+            "bytelength": lambda _v: 4,
+        },
+    )
+    with pytest.raises(
+        ValueError, match="Cannot specify 'format' or 'ptype' with custom serialization callables"
+    ):
+        compile_field(mock_field2)  # type: ignore[arg-type]


### PR DESCRIPTION
## PR: Add Per-Field Custom Serialization Logic via Metadata Callables and FieldSpecCompiledCustom

### Summary

This PR introduces a flexible mechanism for custom serialization and deserialization of fields in serializable dataclasses.  
Instead of requiring a global registry or wrapper classes for non-standard types (such as `uuid.UUID`), it is now possible to specify `serialize`, `deserialize`, and `bytelength` callables directly in the field's `metadata`.  
A new class, `FieldSpecCompiledCustom`, is introduced to handle these fields.  
This enables per-field customization of (de)serialization logic, making the framework more extensible and reducing boilerplate for custom types.

---

### Key Features

- **Per-field serialization logic:**  
  Fields can now specify `serialize`, `deserialize`, and `bytelength` functions in their `metadata`.  
  If present, these are used via the new `FieldSpecCompiledCustom` handler.  
  When using this feature, `format` and `ptype` should not be present.

- **No global registry or wrapper required:**  
  Custom types (e.g., `uuid.UUID`) can be serialized/deserialized without registering them globally or creating wrapper classes.

- **Factory pattern supported:**  
  it is possible to create helper functions (e.g., `field_UUID()`) to easily reuse custom serialization logic for common types.

- **Backwards compatible:**  
  Existing format string and `ptype`-based serialization continues to work as before.  
  The new mechanism is opt-in and does not break existing code.

- **New class:**  
  `FieldSpecCompiledCustom` is introduced to encapsulate the logic for fields with custom serialization callables.

---

### Example Usage

```python
import uuid
from dataclasses import dataclass, field

def field_UUID():
    return field(
        metadata={
            "serialize": lambda obj, buffer, idx: buffer.__setitem__(slice(idx, idx+16), obj.bytes) or idx + 16,
            "deserialize": lambda buffer, idx: (uuid.UUID(bytes=bytes(buffer[idx:idx+16])), idx + 16),
            "bytelength": lambda obj: 16,
        }
    )

@dataclass
class MyEvent:
    correlation_id: uuid.UUID = field_UUID()
```

---

### Implementation Notes

- Add `FieldSpecCompiledCustom`, a new subclass of `FieldSpecCompiled`, which delegates to the provided callables in the field's metadata.
- Update `compile_field` to detect when these callables are present and return a `FieldSpecCompiledCustom` instance.
- Update the serialization logic to use these callables when present.
- Document this feature in the README and provide one example factory for UUID.

---

### Benefits

- Increases flexibility and extensibility of the serialization framework.
- Reduces boilerplate for custom types.
- No global state or registration required.
- Makes it easy to support standard library and third-party types.