### PR TITLE
Add fixed-shape NumPy array serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `?x`       | **Optional primitive**               | 1-byte presence flag + `x` if present                                  | `x` must be one of: `b B h H i I l L q Q e f d y`                     |
 | `T[xx...]` | **Fixed-length tuple of primitives** | Each element serialized consecutively (no prefix)                    | Each `x` must be one of: `b B h H i I l L q Q e f d y`                  |
 | `[np:x]`   | **NumPy array**                      | 1-byte ndim + N×4-byte shape + raw data buffer                         | `x` must be NumPy dtype: `u8`, `u16`, `u32`, `i8`, `i16`, `i32`, `f32`, `f64` |
+| `[np:x:shape]` | **Fixed-shape NumPy array**       | Raw data buffer only; shape is provided in format string                | `shape` is comma-separated dims, e.g. `[np:f32:2,3]` |
 | `S`        | **Variable-length UTF-8 string**     | 4-byte length prefix + UTF-8 encoded bytes                             | -                                                                     |
 | `S[x]`     | **Fixed-length UTF-8 string**        | UTF-8 encoded, space-padded or truncated to `x` bytes (UTF-8 safe)     | -                                                                     |
 | `?S`       | **Optional variable-length UTF-8 string** | 1-byte presence flag + 4-byte length + UTF-8 encoded bytes            | -

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -145,6 +145,11 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
           - '[np:x]' where x is one of 'u8', 'u16', 'u32', 'i8', 'i16', 'i32',
             'f32', 'f64'. The dtype must be fixed for the field.
             Supports arrays of arbitrary dimension.
+          - '[np:x:shape]' where 'shape' is a comma-separated list of
+            integers specifying the fixed array shape (e.g.,
+            '[np:i32:64]' for a vector of length 64, '[np:f32:2,3]' for a
+            2×3 array). The array's shape is omitted from the serialized
+            data, reducing overhead when the shape is known.
 
       - Optional values (nullable) of basic types:
           - '?x' where x is a single struct format character.
@@ -228,7 +233,24 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
             if struct_format.startswith("[np:"):
                 if not struct_format.endswith("]"):
                     raise ValueError("Invalid format: numpy array format string must end with ']'")
-                dtype_key = struct_format[4:-1]
+                inner = struct_format[4:-1]
+                if ":" in inner:
+                    dtype_key, shape_str = inner.split(":", 1)
+                    dtype = _NUMPY_DTYPES.get(dtype_key)
+                    if dtype is None:
+                        raise ValueError("Unsupported numpy dtype")
+                    try:
+                        shape = tuple(int(x) for x in shape_str.split(",") if x)
+                    except ValueError as exc:  # noqa: F841
+                        raise ValueError(
+                            "Invalid format: numpy array shape must be comma-separated integers"
+                        )
+                    if not shape:
+                        raise ValueError(
+                            "Invalid format: numpy array shape must contain at least one dimension"
+                        )
+                    return FieldSpecCompiledFixedNumpyArray(name, dtype, shape)
+                dtype_key = inner
                 dtype = _NUMPY_DTYPES.get(dtype_key)
                 if dtype is None:
                     raise ValueError("Unsupported numpy dtype")
@@ -1189,6 +1211,127 @@ class FieldSpecCompiledOptionalPrimitiveArray(_FieldSpecCompiledOptionalArrayBas
                 The number of bytes used to serialize one element.
         """
         return self._struct_format_byte_length
+
+
+class FieldSpecCompiledFixedNumpyArray(FieldSpecCompiled):
+    """
+    FieldSpecCompiled subclass for fixed-size NumPy arrays of a fixed dtype.
+
+    Serializes the array as a raw contiguous bytes buffer in row-major (C)
+    order. The array's dtype and shape are fixed and verified against the
+    provided value. The serialized form omits the ndim and shape information,
+    reducing overhead when the shape is known at compile time.
+
+    Attributes:
+        dtype (np.dtype[Any]):
+            The required NumPy dtype of the array (e.g., np.uint8, np.float32).
+        shape (tuple[int, ...]):
+            The fixed shape of the array.
+        _byte_len (int):
+            The total number of bytes occupied by the serialized array.
+    """
+
+    dtype: np.dtype[Any]
+    shape: tuple[int, ...]
+    _byte_len: int
+
+    def __init__(self, name: str, dtype: np.dtype[Any], shape: tuple[int, ...]):
+        """
+        Initialize the field for a fixed-size NumPy array.
+
+        Args:
+            name (str):
+                The name of the field.
+
+            dtype (np.dtype[Any]):
+                The NumPy dtype of the array.
+
+            shape (tuple[int, ...]):
+                The fixed shape of the array.
+        """
+        super().__init__(name)
+        self.dtype = np.dtype(dtype)
+        self.shape = tuple(int(s) for s in shape)
+        count = 1
+        for dim in self.shape:
+            count *= dim
+        self._byte_len = count * self.dtype.itemsize
+
+    def serialize_to_bytes(self, class_obj: Any, buffer: bytearray, idx: int) -> int:
+        """
+        Serialize the NumPy array field from `class_obj` into `buffer` at `idx`.
+
+        Args:
+            class_obj (Any):
+                The instance containing the array field.
+
+            buffer (bytearray):
+                The buffer into which to serialize data.
+
+            idx (int):
+                The starting index in the buffer at which to write data.
+
+        Returns:
+            int:
+                The updated buffer index after writing.
+
+        Raises:
+            ValueError: If the array's dtype or shape does not match the
+                required dtype and shape.
+        """
+        arr: NDArray[Any] = getattr(class_obj, self.name)
+        if arr.dtype != self.dtype:
+            raise ValueError("NDArray dtype mismatch")
+        if arr.shape != self.shape:
+            raise ValueError("NDArray shape mismatch")
+        data = arr.tobytes(order="C")
+        buffer[idx:idx + self._byte_len] = data
+        return idx + self._byte_len
+
+    def deserialize_from_bytes(self, buffer: bytes, idx: int) -> Tuple[Any, int]:
+        """
+        Deserialize a fixed-size NumPy array field from `buffer` at `idx`.
+
+        Args:
+            buffer (bytes):
+                The buffer containing serialized data.
+
+            idx (int):
+                The starting index in the buffer at which to read data.
+
+        Returns:
+            Tuple[NDArray, int]:
+                - The deserialized NumPy array.
+                - The updated buffer index after reading.
+        """
+        count = self._byte_len // self.dtype.itemsize
+        arr = np.frombuffer(buffer, dtype=self.dtype, count=count, offset=idx).reshape(self.shape)
+        arr = arr.copy()  # Defensive copy (frombuffer is always read-only)
+        idx += self._byte_len
+        return arr, idx
+
+    def serialized_byte_size(self, class_obj: Any) -> int:
+        """
+        Compute the total number of bytes required to serialize the field.
+
+        Args:
+            class_obj (Any):
+                The instance containing the array field.
+
+        Returns:
+            int:
+                The total byte size for serialization.
+
+        Raises:
+            ValueError: If the array's dtype or shape does not match the fixed
+                dtype and shape.
+        """
+        arr: NDArray[Any] = getattr(class_obj, self.name)
+        if arr.dtype != self.dtype:
+            raise ValueError("NDArray dtype mismatch")
+        if arr.shape != self.shape:
+            raise ValueError("NDArray shape mismatch")
+        return self._byte_len
 
 
 class FieldSpecCompiledNumpyArray(FieldSpecCompiled):

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -384,6 +384,8 @@ def test_super_combo():
 
     ("[np:bad]", None, "Unsupported numpy dtype"),
     ("[np:u8", None, "Invalid format: numpy array format string must end with ']'"),
+    ("[np:u8:1,a]", None, "Invalid format: numpy array shape must be comma-separated integers"),
+    ("[np:u8:]", None, "Invalid format: numpy array shape must contain at least one dimension"),
 
     (None,  None, "Either a type or struct format must be provided"),
 ])
@@ -442,6 +444,24 @@ class TestNumpy3D(FifoSerializable):
     arr: NDArray[np.int16] = field(metadata={"format": "[np:i16]"})
 
 
+@serializable
+@dataclass
+class TestNumpyFixed1D(FifoSerializable):
+    arr: NDArray[np.int32] = field(metadata={"format": "[np:i32:64]"})
+
+
+@serializable
+@dataclass
+class TestNumpyFixed2D(FifoSerializable):
+    arr: NDArray[np.float32] = field(metadata={"format": "[np:f32:2,3]"})
+
+
+@serializable
+@dataclass
+class TestNumpyFixedMatrix(FifoSerializable):
+    arr: NDArray[np.int8] = field(metadata={"format": "[np:i8:3,3]"})
+
+
 def test_numpy_arrays_roundtrip() -> None:
     a1 = np.arange(10, dtype=np.uint8)
     a2 = np.arange(6, dtype=np.float32).reshape(2, 3)
@@ -464,6 +484,30 @@ def test_numpy_arrays_roundtrip() -> None:
         restored_arr = cast(NDArray[Any], restored.arr) # type: ignore
         assert np.array_equal(restored_arr, arr)
         assert restored_arr.dtype == arr.dtype
+
+
+def test_numpy_fixed_arrays_roundtrip() -> None:
+    v1 = np.arange(64, dtype=np.int32)
+    v2 = np.arange(6, dtype=np.float32).reshape(2, 3)
+    v3 = np.arange(9, dtype=np.int8).reshape(3, 3)
+
+    o1 = TestNumpyFixed1D(v1)
+    o2 = TestNumpyFixed2D(v2)
+    o3 = TestNumpyFixedMatrix(v3)
+
+    lst: list[tuple[FifoSerializable, NDArray[Any], Type[FifoSerializable]]] = [
+        (o1, v1, TestNumpyFixed1D),
+        (o2, v2, TestNumpyFixed2D),
+        (o3, v3, TestNumpyFixedMatrix),
+    ]
+
+    for obj, arr, cls in lst:
+        buf = bytearray(obj.serialized_byte_size())
+        obj.serialize_to_bytes(buf, 0)
+        restored, _ = cls.deserialize_from_bytes(buf, 0)
+        restored_arr = cast(NDArray[Any], restored.arr)  # type: ignore
+        assert np.array_equal(restored_arr, arr)
+        assert restored_arr.shape == arr.shape
 
 
 @serializable


### PR DESCRIPTION
## Summary

This PR introduces a new serialization format for NumPy arrays:

- The existing `[np:x]` format serializes arrays of variable length, including dimension and shape in the data.
- The new `[np:x:shape]` format allows specifying the array's shape directly in the format string, using comma-separated values:
    - `[np:i32:64]`: vector of 64 integers
    - `[np:f32:2,3]`: array of shape (2, 3), for example 2 points in 3D
    - `[np:i8:3,3]`: 3x3 matrix

**Benefit:**  
If the array shape is fixed and known, you no longer need to serialize its dimensions and shape, reducing overhead and simplifying (de)serialization.

## Testing
- `pytest -q`