### PR TITLE
Add FifoEventKeepAlive standard event

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,12 @@ In addition to the `FifoEvent` base class, which can be subclassed to create cus
   - `message`: Exception message.
   - `source`: *(Optional)* Identifier of the source (such as thread or worker name).
 
+#### `FifoEventKeepAlive`
+- **Description:** Lightweight keep-alive message containing the epoch timestamp at creation.
+- **Use Case:** Send periodically to indicate that a connection or component is still active.
+- **Fields:**
+  - `epoch`: Timestamp in seconds from `time.time()` when the event was created. Automatically set if not provided.
+
 The `fifo_dev_common` library also includes other classes that inherit from `FifoEvent`, but are intended to be used as a base class for creating standardized events:
 
 #### `FifoEventResultBase`

--- a/fifo_dev_common/event/fifo_event.py
+++ b/fifo_dev_common/event/fifo_event.py
@@ -3,6 +3,7 @@ import asyncio
 from dataclasses import dataclass, field
 from enum import IntEnum
 import struct
+import time
 from typing import Any, Awaitable, Callable, Type, TypeVar, ClassVar
 import threading
 from uuid import UUID, uuid4
@@ -560,6 +561,45 @@ class FifoEventException(FifoEvent):
                                  "is not set")
             self.class_name = class_name
             self.message = message
+
+
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class FifoEventKeepAlive(FifoEvent):
+    """Keep-alive event carrying the current epoch timestamp.
+
+    This standard event can be periodically sent to indicate that a connection
+    or component is still alive. It contains the epoch time at which it was
+    created.
+
+    Attributes:
+        epoch (float):
+            [Serializable] Epoch timestamp of when the event was created.
+            If ``None`` is passed to the constructor, the current time from
+            :func:`time.time` is used.
+    """
+
+    event_id = 2
+    default_priority = 0
+
+    epoch: float = field(metadata={"format": "d"})
+
+    def __init__(self, epoch: float | None = None, priority: int = -1):
+        """Initialize a :class:`FifoEventKeepAlive`.
+
+        Args:
+            epoch (float | None, optional):
+                Explicit epoch timestamp. If ``None`` (default), the current
+                value from :func:`time.time` is used.
+            priority (int, optional):
+                Event priority. If ``-1`` (default), the class's
+                ``default_priority`` is used.
+        """
+        super().__init__(priority=priority)
+        if epoch is None:
+            epoch = time.time()
+        self.epoch = epoch
 
 
 class EErrorCode(IntEnum):

--- a/tests/test_fifo_event.py
+++ b/tests/test_fifo_event.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 import socket
 import struct
 import threading
+import time
 from typing import ClassVar, cast
 from uuid import uuid4
 import pytest
@@ -11,6 +12,7 @@ from fifo_dev_common.event.fifo_event import (
     EErrorCode,
     FifoEvent,
     FifoEventException,
+    FifoEventKeepAlive,
     FifoEventResultBase,
     FifoEventResultWithCID,
     FifoEventWithCID
@@ -359,9 +361,11 @@ def test_clear_registry_allows_re_registration():
 
 
 @pytest.fixture(autouse=True)
-def ensure_fifo_event_exception_registered():
+def ensure_standard_events_registered():
     if FifoEventException.event_id not in FifoEvent._registry:
         FifoEvent.register(FifoEventException)
+    if FifoEventKeepAlive.event_id not in FifoEvent._registry:
+        FifoEvent.register(FifoEventKeepAlive)
 
 
 def test_fifo_event_exception_1():
@@ -399,6 +403,23 @@ def test_fifo_event_exception_3():
         assert event3.class_name == "RuntimeError"
         assert event3.message == "Test message"
         assert event3.source == "Test #3"
+
+
+def test_fifo_event_keepalive_default_epoch():
+    start = time.time()
+    event = FifoEventKeepAlive()
+    end = time.time()
+    assert start <= event.epoch <= end
+    assert event.event_id == 2
+
+
+def test_fifo_event_keepalive_custom_epoch_roundtrip():
+    event = FifoEventKeepAlive(epoch=123.456, priority=5)
+    data = event.to_bytes()
+    event2 = FifoEvent.from_bytes(data)
+    assert isinstance(event2, FifoEventKeepAlive)
+    assert event2.epoch == pytest.approx(123.456)
+    assert event2.priority == 5
 
 
 def test_valueerror_when_both_exception_and_class_name_or_message():


### PR DESCRIPTION
## Summary
- add `FifoEventKeepAlive` standard event carrying an epoch timestamp
- document keep-alive event in README
- test keep-alive event creation and serialization

## Testing
- `pytest -q`