### PR TITLE
Require explicit async output queue for FifoProcessManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It provides the following for runtime type checks and casting, docstring parsing
 - `class FifoEvent`: Base class for binary-serializable events, with factory deserialization and class registration for cross-system use.
 - `class FifoEventQueueForwarderMpToAsync`: Bridges multiprocessing and asyncio event queues via a background thread.
 - `class FifoEventQueueNetworkAsyncClient` / `class FifoEventQueueNetworkAsyncServer`: Asyncio-based network communication for FifoEvent objects over TCP with optional TLS 1.3 encryption.
+- `class FifoProcessManager`: Runs a worker in a separate process and bridges multiprocessing queues with asyncio. Requires an async priority queue for outgoing events.
 - `get_logger()`: Returns a logger instance with `.trace()` support for fine-grained debugging. Registers a custom TRACE level and logger class.
 
 ## 📚 Table of Contents
@@ -42,6 +43,7 @@ It provides the following for runtime type checks and casting, docstring parsing
   - [fifo_event](#fifo_dev_commoneventfifo_event)
   - [fifo_event_queue_forwarder](#fifo_dev_commoneventfifo_event_queue_forwarder)
   - [fifo_event_queue_network](#fifo_dev_commoneventfifo_event_queue_network)
+  - [fifo_process_manager](#fifo_dev_commonprocessutilsfifo_process_manager)
   - [logger](#fifo_dev_commonlogginglogger)
 - [🧪 Tests](#-tests)
 - [📄 License](#-license)
@@ -910,6 +912,44 @@ async def run_client():
 # Run server and client (in practice, these would be separate processes)
 async def main():
     await asyncio.gather(run_server(), run_client())
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+---
+
+### `fifo_dev_common.process.utils.FifoProcessManager`
+
+Run a worker in a separate process and bridge multiprocessing queues with asyncio.
+
+**Example:**
+
+```python
+import asyncio
+from fifo_dev_common.process.utils import FifoProcessManager, FifoAsyncProcessWorkerCallback
+from fifo_dev_common.event.fifo_event import FifoEvent
+
+class Echo(FifoAsyncProcessWorkerCallback):
+    def initialize(self, outgoing_queue: asyncio.PriorityQueue[FifoEvent]):
+        pass
+
+    def finalize(self, outgoing_queue: asyncio.PriorityQueue[FifoEvent]):
+        pass
+
+    async def loop(self, incoming_event, incoming_queue_size, outgoing_queue):
+        if incoming_event is not None:
+            await outgoing_queue.put(incoming_event)
+
+async def main():
+    loop = asyncio.get_running_loop()
+    out_q: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    mgr = FifoProcessManager(loop, Echo(), out_q)
+    mgr.start()
+    await mgr.send(FifoEvent())
+    event = await out_q.get()
+    await mgr.stop()
+    mgr.join()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/fifo_dev_common/process/utils.py
+++ b/fifo_dev_common/process/utils.py
@@ -729,14 +729,14 @@ class FifoProcessManager:
     sync), and manages the threads that transfer events in both directions between the main process
     and the worker process.
 
-    It provides async methods for sending and receiving events, and ensures clean shutdown by
+    It provides async methods for sending events, and ensures clean shutdown by
     propagating shutdown events and joining all threads and the process.
 
     Usage:
-        - Instantiate with an event loop and a worker callback (async or sync).
+        - Instantiate with an event loop, a worker callback (async or sync), and an async
+          output queue.
         - Call `start()` to launch the worker process and communication threads.
-        - Use `send()`, `send_and_wait_response()` and `receive()` to asynchronously
-          exchange events.
+        - Use `send()` and `send_and_wait_response()` to asynchronously send events.
         - Call `stop()` to shut down the worker process.
         - Call `join()` to wait for all threads and the process to exit.
 
@@ -790,11 +790,11 @@ class FifoProcessManager:
     def __init__(self,
                  loop: asyncio.AbstractEventLoop,
                  callback: FifoAsyncProcessWorkerCallback | FifoSyncProcessWorkerCallback,
-                 async_out: asyncio.PriorityQueue[FifoEvent] | None = None
+                 async_out: asyncio.PriorityQueue[FifoEvent]
                  ) -> None:
         """
-        Initialize the process manager with an event loop, worker callback, and optional async
-        output queue. If no async output queue is provided, a new one is created.
+        Initialize the process manager with an event loop, worker callback, and async
+        output queue.
 
         Args:
             loop (asyncio.AbstractEventLoop):
@@ -803,8 +803,8 @@ class FifoProcessManager:
             callback (FifoAsyncProcessWorkerCallback | FifoSyncProcessWorkerCallback):
                 The worker callback (async or sync) to run in the worker process.
 
-            async_out (asyncio.PriorityQueue[FifoEvent] | None):
-                Optional async priority queue for outgoing events in the main process.
+            async_out (asyncio.PriorityQueue[FifoEvent]):
+                Async priority queue for outgoing events in the main process.
         """
         self._loop = loop
 
@@ -815,7 +815,7 @@ class FifoProcessManager:
         self._out_queue = Queue()
 
         self._async_in: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
-        self._async_out = asyncio.PriorityQueue() if async_out is None else async_out
+        self._async_out = async_out
 
         if isinstance(callback, FifoAsyncProcessWorkerCallback):
             self._proc = Process(target=_runner_async,
@@ -940,19 +940,6 @@ class FifoProcessManager:
         _trace("[FifoProcessManager.fct:send] Result received (ack/done)")
 
         return result
-
-    async def receive(self) -> FifoEvent:
-        """
-        Asynchronously receive the next event from the worker process.
-
-        Returns:
-            FifoEvent:
-                The next event produced by the worker process.
-        """
-        _trace("[FifoProcessManager.fct:receive] Awaiting event from worker")
-        event = await self._async_out.get()
-        _trace("[FifoProcessManager.fct:receive] Event received from worker")
-        return event
 
     def _in_queue_pusher(self) -> None:
         """

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -108,7 +108,8 @@ class ErrorSyncCallback(FifoSyncProcessWorkerCallback):
 @pytest.mark.parametrize("timeout", [-1, 0, 0.5])
 async def test_async_process_manager_echo(timeout: float):
     loop = asyncio.get_event_loop()
-    process = FifoProcessManager(loop, DemoFifoAsyncProcessWorkerCallback(timeout=timeout))
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    process = FifoProcessManager(loop, DemoFifoAsyncProcessWorkerCallback(timeout=timeout), out_queue)
     process.start()
 
     await process.send(FifoEvent(priority=2))
@@ -117,7 +118,7 @@ async def test_async_process_manager_echo(timeout: float):
 
     received: list[int] = []
     for _ in range(3):
-        event = await process.receive()
+        event = await out_queue.get()
         received.append(event.priority)
 
     await asyncio.sleep(1)
@@ -132,7 +133,8 @@ async def test_async_process_manager_echo(timeout: float):
 def test_sync_process_manager_echo():
     # Run sync worker in a subprocess, communicate via queues
     loop = asyncio.new_event_loop()
-    process = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    process = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback(), out_queue)
     process.start()
 
     async def send_and_receive():
@@ -142,7 +144,7 @@ def test_sync_process_manager_echo():
 
         received: list[int] = []
         for _ in range(3):
-            event = await process.receive()
+            event = await out_queue.get()
             received.append(event.priority)
 
         await process.stop()
@@ -156,7 +158,8 @@ def test_sync_process_manager_echo():
 @pytest.mark.asyncio
 async def test_async_process_manager_shutdown_event():
     loop = asyncio.get_event_loop()
-    process = FifoProcessManager(loop, DemoFifoAsyncProcessWorkerCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    process = FifoProcessManager(loop, DemoFifoAsyncProcessWorkerCallback(), out_queue)
     process.start()
 
     await process.send(FifoEventShutdown())
@@ -167,11 +170,12 @@ async def test_async_process_manager_shutdown_event():
 @pytest.mark.asyncio
 async def test_async_exception_event_propagation():
     loop = asyncio.get_event_loop()
-    process = FifoProcessManager(loop, ErrorAsyncCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    process = FifoProcessManager(loop, ErrorAsyncCallback(), out_queue)
     process.start()
 
     await process.send(FifoEvent())
-    event = await process.receive()
+    event = await out_queue.get()
 
     assert isinstance(event, FifoEventException)
     assert event.class_name == "RuntimeError"
@@ -183,12 +187,13 @@ async def test_async_exception_event_propagation():
 
 def test_sync_exception_event_propagation():
     loop = asyncio.new_event_loop()
-    process = FifoProcessManager(loop, ErrorSyncCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    process = FifoProcessManager(loop, ErrorSyncCallback(), out_queue)
     process.start()
 
     async def send_and_receive():
         await process.send(FifoEvent())
-        event = await process.receive()
+        event = await out_queue.get()
         await process.stop()
         process.join()
         return event
@@ -220,7 +225,8 @@ class TestDone(FifoEventResultWithCID):
 @pytest.mark.asyncio
 async def test_update_received_correlation_id_unmatched():
     loop = asyncio.get_event_loop()
-    manager = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    manager = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback(), out_queue)
     event = TestAck(code=EErrorCode.OK, correlation_id=uuid4())
 
     await manager._update_received_correlation_id(event)
@@ -231,7 +237,8 @@ async def test_update_received_correlation_id_unmatched():
 @pytest.mark.asyncio
 async def test_send_and_wait_response_ack_done():
     loop = asyncio.get_event_loop()
-    manager = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    manager = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback(), out_queue)
     request = TestRequest()
 
     task = asyncio.create_task(
@@ -253,7 +260,8 @@ async def test_send_and_wait_response_ack_done():
 @pytest.mark.asyncio
 async def test_send_and_wait_response_ack_error():
     loop = asyncio.get_event_loop()
-    manager = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    manager = FifoProcessManager(loop, DemoFifoSyncProcessWorkerCallback(), out_queue)
     request = TestRequest()
 
     task = asyncio.create_task(
@@ -299,7 +307,8 @@ async def test_send_and_wait_response_end_to_end():
     """Verify send_and_wait_response works with a running process manager."""
     loop = asyncio.get_event_loop()
 
-    manager = FifoProcessManager(loop, Worker())
+    out_queue: asyncio.PriorityQueue[FifoEvent] = asyncio.PriorityQueue()
+    manager = FifoProcessManager(loop, Worker(), out_queue)
     manager.start()
 
     done = await manager.send_and_wait_response(TestRequest(), TestAck, TestDone)


### PR DESCRIPTION
## Summary
- require `async_out` queue in `FifoProcessManager` constructor and remove `receive()` method
- document `FifoProcessManager` with new example and describe retrieving events from provided queue
- update tests to supply explicit output queues

## Testing
- `pytest tests`