### PR TITLE
Add SupportsFifoEventPut protocol and put alias for network queues

### DIFF
--- a/fifo_dev_common/event/fifo_event_protocols.py
+++ b/fifo_dev_common/event/fifo_event_protocols.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Protocol, runtime_checkable
+
+from fifo_dev_common.event.fifo_event import FifoEvent
+
+
+@runtime_checkable
+class SupportsFifoEventPut(Protocol):
+    """
+    Protocol for accepting FifoEvent instances via put.
+    """
+
+    async def put(self, event: FifoEvent) -> None:
+        """
+        Asynchronously enqueue a FifoEvent.
+
+        Args:
+            event (FifoEvent):
+                Event to enqueue.
+        """
+        ...
+
+
+__all__ = ["SupportsFifoEventPut"]

--- a/fifo_dev_common/event/fifo_event_queue_network.py
+++ b/fifo_dev_common/event/fifo_event_queue_network.py
@@ -17,6 +17,7 @@ import ssl
 import hashlib
 from typing import Optional, Sequence, cast
 from fifo_dev_common.event.fifo_event import FifoEvent, FifoEventShutdown
+from fifo_dev_common.event.fifo_event_protocols import SupportsFifoEventPut
 from fifo_dev_common.logging.logger import get_logger
 
 logger = get_logger(__name__)
@@ -363,8 +364,23 @@ class _FifoEventQueueNetworkAsyncMixin:
         """
         await event.serialize_to_socket_async(self._writer)  # drain handled by serializer
 
+    async def put(self, event: FifoEvent) -> None:
+        """
+        Queue-like alias for send.
 
-class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin):
+        Provides compatibility with asyncio.PriorityQueue.put so that network
+        clients and servers can be used interchangeably with asyncio queues
+        expecting a put method.
+
+        Args:
+            event (FifoEvent):
+                Event to send over the network connection.
+        """
+
+        await self.send(event)
+
+
+class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, SupportsFifoEventPut):
     """
     Asyncio-based network client for sending and receiving FifoEvent objects over TCP.
 
@@ -548,7 +564,7 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin):
         await _bounded_close_and_wait_closed_writer(self._writer, timeout=3.0, label="client")
 
 
-class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin):
+class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, SupportsFifoEventPut):
     """
     Asyncio-based network server for sending and receiving FifoEvent objects over TCP.
 

--- a/tests/test_fifo_event_queue_network_async.py
+++ b/tests/test_fifo_event_queue_network_async.py
@@ -76,15 +76,25 @@ async def test_client_server_roundtrip(use_tls: bool, unused_tcp_port: int):
     )
     server = await server_task
 
-    await client.send(DummyEvent(value=1))
+    await client.put(DummyEvent(value=1))
     recv = await server._out_queue.get()
     assert isinstance(recv, DummyEvent)
     assert recv.value == 1
 
-    await server.send(DummyEvent(value=2))
-    recv = await client._out_queue.get()
+    await client.send(DummyEvent(value=2))
+    recv = await server._out_queue.get()
     assert isinstance(recv, DummyEvent)
     assert recv.value == 2
+
+    await server.put(DummyEvent(value=3))
+    recv = await client._out_queue.get()
+    assert isinstance(recv, DummyEvent)
+    assert recv.value == 3
+
+    await server.send(DummyEvent(value=4))
+    recv = await client._out_queue.get()
+    assert isinstance(recv, DummyEvent)
+    assert recv.value == 4
 
     await client.stop()
     await server.stop()


### PR DESCRIPTION
## Summary
- Add a runtime-checkable `SupportsFifoEventPut` protocol defining an asynchronous `put()` interface for `FifoEvent` instances
- Add a `put()` alias in the network queue mixin and had the client and server classes inherit the new protocol for queue-like interoperability
- Update network tests to send events through the new `put()` method on both client and server, verifying round-trip behavior

## Testing
- `pytest -q`