### PR TITLE
Add optional fixed-length tuple serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `[x]`      | **Array of primitives**              | 4-byte length prefix + consecutive `x` values                          | `x` must be one of: `b B h H i I l L q Q e f d y`                     |
 | `[?x]`     | **Array of optional primitives**     | 4-byte length + presence bitmap + serialized values for present items  | `x` must be one of: `b B h H i I l L q Q e f d y`                     |
 | `?x`       | **Optional primitive**               | 1-byte presence flag + `x` if present                                  | `x` must be one of: `b B h H i I l L q Q e f d y`                     |
-| `T[xx...]` | **Fixed-length tuple of primitives** | Each element serialized consecutively (no prefix)                    | Each `x` must be one of: `b B h H i I l L q Q e f d y`                  |
+| `T<xx...>` | **Fixed-length tuple of primitives** | Each element serialized consecutively (no prefix)                    | Each `x` must be one of: `b B h H i I l L q Q e f d y`                  |
+| `?T<xx...>` | **Optional fixed-length tuple of primitives** | 1-byte presence flag + serialized elements if present | Each `x` must be one of: `b B h H i I l L q Q e f d y` |
 | `[np:x]`   | **NumPy array**                      | 1-byte ndim + N×4-byte shape + raw data buffer                         | `x` must be NumPy dtype: `u8`, `u16`, `u32`, `i8`, `i16`, `i32`, `f32`, `f64` |
 | `[np:x:shape]` | **Fixed-shape NumPy array**       | Raw data buffer only; shape is provided in format string                | `shape` is comma-separated dims, e.g. `[np:f32:2,3]` |
 | `S`        | **Variable-length UTF-8 string**     | 4-byte length prefix + UTF-8 encoded bytes                             | -                                                                     |

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -137,6 +137,11 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
             Only basic types are supported inside the tuple. Nested tuples, arrays, or optional
             values are not supported in the current version.
 
+      - Optional fixed-size tuple of basic types:
+          - '?T<xy...>' where x, y, ... are struct format characters.
+            Example: '?T<II>' means an optional tuple of two ints.
+            Serialized as a 1-byte presence flag followed by the tuple data if present.
+
       - Fixed-length array of basic types:
           - '[x]' where x is a single struct format character.
             Example: '[f]' means a variable-length array of floats.
@@ -287,6 +292,25 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
                     _format_error("primitive types in arrays", _ALLOWED_STRUCT_FORMAT_CHARS)
                 )
             return FieldSpecCompiledArray(name, element_type)
+
+        if struct_format.startswith("?T<"):
+            if not (len(struct_format) >= 5 and struct_format[-1] == ">"):
+                raise ValueError(
+                    "Invalid format: tuple format must start with '?T<', end with '>', "
+                    "and contain at least one format character"
+                )
+            inner_types = struct_format[3:-1]
+            try:
+                struct.calcsize('<' + inner_types.replace('y', 'B'))
+            except struct.error as exc:
+                raise ValueError(
+                    "Invalid format: tuple format is not valid struct syntax"
+                ) from exc
+            if any(c not in _ALLOWED_STRUCT_FORMAT_CHARS for c in inner_types):
+                raise ValueError(
+                    _format_error("tuple types", _ALLOWED_STRUCT_FORMAT_CHARS)
+                )
+            return FieldSpecCompiledOptionalTuple(name, inner_types)
 
         if struct_format.startswith("?S["):
             if not struct_format.endswith("]"):
@@ -1973,6 +1997,96 @@ class FieldSpecCompiledTuple(FieldSpecCompiled):
                 The total byte size needed to serialize the tuple.
         """
         return self._struct_format_byte_length
+
+
+class FieldSpecCompiledOptionalTuple(FieldSpecCompiledTuple):
+    """
+    Optional fixed-size tuple of primitive values with presence flag.
+
+    Serializes a tuple prefixed by a one-byte presence flag. If the field
+    value is None, only the flag byte is written. Otherwise, the flag byte
+    is set to 1 followed by the packed tuple values using the configured
+    struct format.
+
+    Attributes:
+        struct_format (str):
+            Struct format string for the tuple elements.
+
+        _struct_format_byte_length (int):
+            The fixed size of the serialized tuple in bytes.
+    """
+
+    def serialize_to_bytes(self, class_obj: Any, buffer: bytearray, idx: int) -> int:
+        """
+        Serialize the optional tuple field into the buffer starting at idx.
+
+        Args:
+            class_obj (Any):
+                Instance containing the field value.
+
+            buffer (bytearray):
+                Destination buffer for serialized bytes.
+
+            idx (int):
+                Starting index within the buffer.
+
+        Returns:
+            int:
+                Updated buffer index after writing data.
+        """
+        values = getattr(class_obj, self.name)
+        if values is None:
+            buffer[idx] = 0
+            return idx + 1
+        buffer[idx] = 1
+        struct.pack_into('<' + self.struct_format, buffer, idx + 1, *values)
+        return idx + 1 + self._struct_format_byte_length
+
+    def deserialize_from_bytes(self, buffer: bytes, idx: int) -> Tuple[Any, int]:
+        """
+        Deserialize the optional tuple from the buffer starting at idx.
+
+        Args:
+            buffer (bytes):
+                Source buffer containing serialized data.
+
+            idx (int):
+                Starting index within the buffer.
+
+        Returns:
+            Tuple[Any, int]:
+                A tuple (value, new_idx) where value is either the
+                deserialized tuple or None if absent, and new_idx is the
+                index after reading the data.
+        """
+        present = buffer[idx]
+        idx += 1
+        if not present:
+            return None, idx
+        obj = struct.unpack_from('<' + self.struct_format, buffer, idx)
+        if self._has_bool:
+            obj = tuple(
+                bool(v) if flag else v
+                for v, flag in zip(obj, self._bool_flags)
+            )
+        return obj, idx + self._struct_format_byte_length
+
+    def serialized_byte_size(self, class_obj: Any) -> int:
+        """
+        Compute the byte size of the serialized optional tuple field.
+
+        Args:
+            class_obj (Any):
+                Instance containing the field value.
+
+        Returns:
+            int:
+                Total number of bytes required to serialize this field.
+        """
+        values = getattr(class_obj, self.name)
+        if values is None:
+            return 1
+        return 1 + self._struct_format_byte_length
 
 
 class FieldSpecCompiledGeneric(FieldSpecCompiled):

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -251,6 +251,32 @@ def test_tuple_mixed():
 
 @serializable
 @dataclass
+class TestOptionalTuple(FifoSerializable):
+    maybe: tuple[int, float] | None = field(metadata={"format": "?T<If>"})
+
+
+def test_optional_tuple_roundtrip() -> None:
+    obj = TestOptionalTuple((7, 1.5))
+    size = obj.serialized_byte_size()
+    assert size == 1 + struct.calcsize('<If')
+    buf = bytearray(size)
+    obj.serialize_to_bytes(buf, 0)
+    restored, _ = TestOptionalTuple.deserialize_from_bytes(buf, 0)
+    assert restored.maybe is not None
+    assert restored.maybe[0] == 7
+    assert math.isclose(restored.maybe[1], 1.5, rel_tol=1e-6, abs_tol=1e-8)
+
+    obj_none = TestOptionalTuple(None)
+    size_none = obj_none.serialized_byte_size()
+    assert size_none == 1
+    buf2 = bytearray(size_none)
+    obj_none.serialize_to_bytes(buf2, 0)
+    restored_none, _ = TestOptionalTuple.deserialize_from_bytes(buf2, 0)
+    assert restored_none.maybe is None
+
+
+@serializable
+@dataclass
 class TestOptionalArray(FifoSerializable):
     items: list[TestBasic | None] = field(metadata={"format": "[?_]", "ptype": TestBasic})
 
@@ -373,6 +399,12 @@ def test_super_combo():
     ("T<__>", None, "Invalid format: tuple format is not valid struct syntax"),
     ("T<x>", None, "Format string for tuple types only supports the following characters"),
     ("T<bBx>", None, "Format string for tuple types only supports the following characters"),
+
+    ("?T<", None, "Invalid format: tuple format must start with '\\?T<', end with '>', and contain at least one format character"),
+    ("?T<>", None, "Invalid format: tuple format must start with '\\?T<', end with '>', and contain at least one format character"),
+    ("?T<__>", None, "Invalid format: tuple format is not valid struct syntax"),
+    ("?T<x>", None, "Format string for tuple types only supports the following characters"),
+    ("?T<bBx>", None, "Format string for tuple types only supports the following characters"),
 
     ("S[", None, "Invalid format: fixed-length string must end with ']'"),
     ("S[]", None, "Invalid format: fixed-length string must contain a numeric length"),


### PR DESCRIPTION
## Summary
- support `?T<...>` optional fixed-length tuple format
- implement `FieldSpecCompiledOptionalTuple` with presence flag
- document optional tuple serialization and add tests

## Testing
- `pytest -q`