### PR TITLE
Allow explicit '_' format for nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `?S`       | **Optional variable-length UTF-8 string** | 1-byte presence flag + 4-byte length + UTF-8 encoded bytes            | -
 | `?S[x]`    | **Optional fixed-length UTF-8 string**    | 1-byte presence flag + UTF-8 encoded, space-padded or truncated to `x` bytes | -
 | `E<x>`     | **Enum stored as integer**           | Stored as `x` (e.g., `B`, `H`, `I`)                                    | `x` must be one of: `b B h H i I`                                     |
+| `_`        | **Nested object**                    | Nested serialization using `ptype`                                     | Requires `ptype`; equivalent to omitting `format`                     |
 | `?_`       | **Optional nested object**           | 1-byte presence flag + nested serialization if present                 | -                                                                     |
 | `[_]`      | **Array of nested objects**          | 4-byte length prefix + consecutive nested serializations               | -                                                                     |
 | `[?_]`     | **Array of optional nested objects** | 4-byte length + presence bitmap + serialized present objects           | -                                                                     |

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -164,6 +164,10 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
           - '?_' indicates an optional nested object.
             Requires 'ptype' metadata specifying the nested class type.
 
+      - Generic nested serializable object:
+          - '_' indicates a nested object.
+            Requires 'ptype' metadata specifying the class type.
+
       - Generic array of nested serializable objects:
           - '[_]' indicates a variable-length array of nested objects.
             Requires 'ptype' metadata specifying the element class type.
@@ -174,7 +178,7 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
             Requires 'ptype' metadata specifying the element class type.
 
       - No format specified:
-          - Assumes a nested serializable object.
+          - Assumes a nested serializable object (same as specifying '_').
             Requires 'ptype' metadata specifying the class type.
 
     Args:
@@ -234,6 +238,10 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
         return FieldSpecCompiledCustom(name, serialize_fn, deserialize_fn, bytelength_fn)
 
     if struct_format is not None:
+        if struct_format == "_":
+            if ptype is None:
+                raise ValueError("Type must be provided for generic object")
+            return FieldSpecCompiledGeneric(name, ptype)
         if struct_format[0] == "[":
             if struct_format.startswith("[np:"):
                 if not struct_format.endswith("]"):

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -83,6 +83,25 @@ def test_basic():
 
 @serializable
 @dataclass
+class TestExplicitNested(FifoSerializable):
+    item: TestBasic = field(metadata={"format": "_", "ptype": TestBasic})
+
+
+def test_explicit_nested_format():
+    obj = TestExplicitNested(TestBasic(5, 6))
+    size = obj.serialized_byte_size()
+    expected = TestBasic(0, 0).serialized_byte_size()
+    assert size == expected
+
+    buf = bytearray(size)
+    obj.serialize_to_bytes(buf, 0)
+
+    restored, _ = TestExplicitNested.deserialize_from_bytes(buf, 0)
+    assert restored.item.a == 5 and restored.item.b == 6
+
+
+@serializable
+@dataclass
 class TestOptional(FifoSerializable):
     a: int | None = field(metadata={"format": "?I"})
     b: int | None = field(metadata={"format": "?I"})
@@ -382,7 +401,9 @@ def test_super_combo():
     ("[x]", None, "Format string for primitive types in arrays only supports the following characters"),
 
     ("P",   None, "Format string for primitive types only supports the following characters"),
-    
+
+    ("_",   None, "Type must be provided for generic object"),
+
     ("?",   None, "Invalid format: optional format must be two characters"),
     ("?__", None, "Invalid format: optional format must be two characters"),
     ("?_",  None, "Type must be provided for generic optional"),
@@ -425,6 +446,8 @@ def test_compile_field_value_errors(format_string: str | None, ptype: Type[Any] 
     metadata = {}
     if format_string is not None:
         metadata["format"] = format_string
+    if ptype is not None:
+        metadata["ptype"] = ptype
     # Simulate a dataclass Field with .name and .metadata
     mock_field = SimpleNamespace(name="x", metadata=metadata, ptype=ptype)
     with pytest.raises(ValueError, match=err_msg):


### PR DESCRIPTION
## Summary
- Support specifying `format: "_"` for nested serializable dataclass fields
- Document `_` format in README
- Test explicit `_` format and validation logic, including missing `ptype`
- Populate `ptype` in error-test metadata for completeness

## Testing
- `pytest`

## Rationale
Currently the format `"_"` is implicit and cannot be specified. For example, to serialize a nested object, only `ptype` is passed in the metadata:

```python
points: Coordinates = field(metadata={"ptype": Coordinates})
```

For symmetry with other format strings, add support for `"_"`.  
The current logic is unchanged for backward compatibility.

The following two formats are now equivalent:

```python
points: Coordinates = field(metadata={"format": "_", "ptype": Coordinates})
```

```python
points: Coordinates = field(metadata={"ptype": Coordinates})
```