### PR TITLE
Add async network event handlers with correlation ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ Asyncio-based TCP transport for `FifoEvent` objects, with optional TLS 1.3 encry
 - `FifoEventQueueNetworkAsyncClient`: sends events immediately; receives events in a background task and enqueues them in a local `asyncio.PriorityQueue`.
 - `FifoEventQueueNetworkAsyncServer`: accepts **exactly one** client at a time (additional clients are rejected until the connection closes); sends events immediately and receives events in a background task, enqueuing them in a local `asyncio.PriorityQueue`.
 - `make_server_tls_context()` / `make_client_tls_context()`: helpers to build **TLS 1.3–only** SSL contexts.
+- Optional pre-queue async handlers to process and optionally consume incoming events; includes a built-in correlation-ID handler for acknowledgements.
 - Optional mutual TLS (mTLS): peer authentication.
 - Scope: transport layer only (no application-layer authentication/authorization).
 

--- a/fifo_dev_common/event/fifo_event_queue_network.py
+++ b/fifo_dev_common/event/fifo_event_queue_network.py
@@ -15,9 +15,18 @@ import threading
 import contextlib
 import ssl
 import hashlib
-from typing import Optional, Sequence, cast
-from fifo_dev_common.event.fifo_event import FifoEvent, FifoEventShutdown
+from typing import Awaitable, Callable, Optional, Sequence, cast
+from fifo_dev_common.event.fifo_event import (
+    FifoEvent,
+    FifoEventShutdown,
+    FifoEventResultWithCID,
+    FifoEventWithCID,
+)
 from fifo_dev_common.event.fifo_event_protocols import SupportsFifoEventPut
+from fifo_dev_common.event.fifo_event_queue_network_handler import (
+    FifoEventQueueNetworkAsyncHandlerBase,
+    FifoEventQueueNetworkAsyncHandlerCID,
+)
 from fifo_dev_common.logging.logger import get_logger
 
 logger = get_logger(__name__)
@@ -310,6 +319,7 @@ class _FifoEventQueueNetworkAsyncMixin:
     _writer: asyncio.StreamWriter
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _task: asyncio.Task[None]
+    _handler: FifoEventQueueNetworkAsyncHandlerBase
 
     async def stop(self):
         """
@@ -344,7 +354,9 @@ class _FifoEventQueueNetworkAsyncMixin:
                 logger.error("[%s] Error receiving event: %r", role, type(e))
                 continue
 
-            await self._out_queue.put(event)
+            processed = await self._handler.process_event(event)
+            if not processed:
+                await self._out_queue.put(event)
             if isinstance(event, FifoEventShutdown):
                 break
 
@@ -363,6 +375,29 @@ class _FifoEventQueueNetworkAsyncMixin:
             ConnectionError: If the connection is closed or there's a network error.
         """
         await event.serialize_to_socket_async(self._writer)  # drain handled by serializer
+
+    def register(self,
+                 event: FifoEventWithCID,
+                 expected_cls: Sequence[type[FifoEventResultWithCID]] | Sequence[Sequence[type[FifoEventResultWithCID]]],
+                 callback: Callable[[FifoEventResultWithCID], Awaitable[bool]]):
+        """
+        Register a callback to be invoked when a matching event is received.
+
+        Args:
+            event (FifoEventWithCID):
+                The event being sent that carries a correlation identifier.
+
+            expected_cls (Sequence[type[FifoEventResultWithCID]] | Sequence[Sequence[type[FifoEventResultWithCID]]]):
+                One or more sequences of expected response event classes. Each inner
+                sequence represents a stage of possible events, processed in order.
+
+            callback (Callable[[FifoEventResultWithCID], Awaitable[bool]]):
+                Asynchronous method invoked when the event is received. It returns
+                True to continue waiting for subsequent stages or False to stop
+                processing further events for the correlation ID.
+        """
+
+        self._handler.register(event, expected_cls, callback)
 
     async def put(self, item: FifoEvent) -> None:
         """
@@ -413,17 +448,22 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
         _task (asyncio.Task[None]):
             Background asyncio task that continuously receives events from the network
             and places them in the output queue.
+
+        _handler (FifoEventQueueNetworkAsyncHandlerBase):
+            Handler used to process incoming events before queuing.
     """
     _reader: asyncio.StreamReader
     _writer: asyncio.StreamWriter
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _thread: threading.Thread
     _task: asyncio.Task[None]
+    _handler: FifoEventQueueNetworkAsyncHandlerBase
 
     def __init__(self,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter,
-                 out_queue: asyncio.PriorityQueue[FifoEvent] | None):
+                 out_queue: asyncio.PriorityQueue[FifoEvent] | None,
+                 handler: FifoEventQueueNetworkAsyncHandlerBase | None = None):
         """
         Initialize a FifoEventQueueNetworkAsyncClient with existing connection streams.
 
@@ -436,10 +476,15 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
 
             out_queue (asyncio.PriorityQueue[FifoEvent] | None):
                 Optional priority queue for received events. If None, a new queue is created.
+
+            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+                Handler used to process incoming events. If None, a default
+                correlation ID handler is used.
         """
         self._reader = reader
         self._writer = writer
         self._out_queue = out_queue or asyncio.PriorityQueue()
+        self._handler = handler or FifoEventQueueNetworkAsyncHandlerCID()
         self._task = asyncio.create_task(self._network_to_queue())
 
     @classmethod
@@ -447,6 +492,7 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
                       host: str,
                       port: int,
                       out_queue: asyncio.PriorityQueue[FifoEvent] | None = None,
+                      handler: FifoEventQueueNetworkAsyncHandlerBase | None = None,
                       *,
                       ssl_ctx: ssl.SSLContext | None = None,
                       server_hostname: str | None = None,
@@ -469,6 +515,10 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
 
             out_queue (asyncio.PriorityQueue[FifoEvent] | None, optional):
                 Optional priority queue for received events. If None, a new queue is created.
+
+            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+                Handler used to process incoming events. If None, a default
+                correlation ID handler is used.
 
             ssl_ctx (ssl.SSLContext | None, optional):
                 SSL context configured for TLS 1.3. If provided, enables TLS.
@@ -532,7 +582,7 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
         if ssl_ctx is not None:
             _log_tls_peer(writer, "client")
 
-        return cls(reader, writer, out_queue)
+        return cls(reader, writer, out_queue, handler)
 
     async def join(self, timeout: float = 5.0):
         """
@@ -562,6 +612,7 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
 
         # Close writer with a bounded wait
         await _bounded_close_and_wait_closed_writer(self._writer, timeout=3.0, label="client")
+        await self._handler.join()
 
 
 class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, SupportsFifoEventPut):
@@ -598,18 +649,23 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
         _task (asyncio.Task[None]):
             Background asyncio task that continuously receives events from the client
             and places them in the output queue.
+
+        _handler (FifoEventQueueNetworkAsyncHandlerBase):
+            Handler used to process incoming events before queuing.
     """
     _reader: asyncio.StreamReader
     _writer: asyncio.StreamWriter
     _server: asyncio.Server
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _task: asyncio.Task[None]
+    _handler: FifoEventQueueNetworkAsyncHandlerBase
 
     def __init__(self,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter,
                  server: asyncio.Server,
-                 out_queue: asyncio.PriorityQueue[FifoEvent] | None):
+                 out_queue: asyncio.PriorityQueue[FifoEvent] | None,
+                 handler: FifoEventQueueNetworkAsyncHandlerBase | None = None):
         """
         Initialize a FifoEventQueueNetworkAsyncServer with existing connection and server.
 
@@ -625,11 +681,16 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
 
             out_queue (asyncio.PriorityQueue[FifoEvent] | None):
                 Optional priority queue for received events. If None, a new queue is created.
+
+            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+                Handler used to process incoming events. If None, a default
+                correlation ID handler is used.
         """
         self._reader = reader
         self._writer = writer
         self._server = server
         self._out_queue = out_queue or asyncio.PriorityQueue()
+        self._handler = handler or FifoEventQueueNetworkAsyncHandlerCID()
         self._task = asyncio.create_task(self._network_to_queue())
 
     @classmethod
@@ -637,6 +698,7 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
                      host: str,
                      port: int,
                      out_queue: asyncio.PriorityQueue[FifoEvent] | None = None,
+                     handler: FifoEventQueueNetworkAsyncHandlerBase | None = None,
                      *,
                      ssl_ctx: ssl.SSLContext | None = None,
                      require_tls: bool = False):
@@ -658,6 +720,10 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
 
             out_queue (asyncio.PriorityQueue[FifoEvent] | None, optional):
                 Optional priority queue for received events. If None, a new queue is created.
+
+            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+                Handler used to process incoming events. If None, a default
+                correlation ID handler is used.
 
             ssl_ctx (ssl.SSLContext | None, optional):
                 SSL context configured for TLS 1.3. If provided, enables TLS for the server.
@@ -712,7 +778,7 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
 
         # Enforce "one client at a time": stop listening once connected (defer wait to join)
         server.close()
-        return cls(reader, writer, server, out_queue)
+        return cls(reader, writer, server, out_queue, handler)
 
     async def join(self, timeout: float = 5.0):
         """
@@ -745,3 +811,4 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
 
         # Listener was closed in accept(); now wait for it to finish closing
         await _bounded_wait_closed_server(self._server, timeout=3.0)
+        await self._handler.join()

--- a/fifo_dev_common/event/fifo_event_queue_network_handler.py
+++ b/fifo_dev_common/event/fifo_event_queue_network_handler.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from typing import Awaitable, Callable, Dict, Sequence
+from uuid import UUID
+
+from fifo_dev_common.event.fifo_event import (
+    FifoEvent,
+    FifoEventResultWithCID,
+    FifoEventShutdown,
+    FifoEventWithCID,
+)
+from fifo_dev_common.logging.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def _async_noop(_: FifoEvent) -> None:
+    """
+    Asynchronous no-op function used for shutdown.
+    """
+    return
+
+
+class FifoEventQueueNetworkAsyncHandlerBase(ABC):
+    """Base class for asynchronous network event handlers.
+
+    This handler processes callbacks on a background task so that the network
+    reader is never blocked. Derived classes should implement :py:meth:`register`
+    and may override :py:meth:`process_event`.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the handler and start the background processing task.
+        """
+        self._queue: asyncio.Queue[tuple[Callable[[FifoEvent], Awaitable[None]], FifoEvent]]
+        self._queue = asyncio.Queue()
+        self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        while True:
+            callback, event = await self._queue.get()
+            if isinstance(event, FifoEventShutdown):
+                break
+            try:
+                await callback(event)
+            except Exception:  # pragma: no cover
+                logger.exception("handler callback failed")
+
+    async def join(self) -> None:
+        """
+        Wait for the handler background task to finish.
+        """
+        await self._task
+
+    @abstractmethod
+    def register(self,
+                 event: FifoEventWithCID,
+                 expected_cls: Sequence[type[FifoEventResultWithCID]] | Sequence[Sequence[type[FifoEventResultWithCID]]],
+                 callback: Callable[[FifoEventResultWithCID], Awaitable[bool]]) -> None:
+        """
+        Register a callback for a specific incoming event.
+
+        Args:
+            event (FifoEventWithCID):
+                Event object being sent and for which a response is expected.
+
+            expected_cls (Sequence[type[FifoEventResultWithCID]] | Sequence[Sequence[type[FifoEventResultWithCID]]]):
+                One or more sequences of expected event classes. Each inner sequence
+                represents a stage of possible events processed in order.
+
+            callback (Callable[[FifoEventResultWithCID], Awaitable[bool]]):
+                Asynchronous function invoked when the matching event is received. It
+                returns True to continue to the next stage or False to stop further
+                processing for the correlation ID.
+        """
+
+    async def process_event(self, event: FifoEvent) -> bool:
+        """
+        Process an incoming event.
+
+        Args:
+            event (FifoEvent):
+                Incoming event from the network.
+
+        Returns:
+            bool:
+                True if the event has been processed by the handler and should
+                not be inserted into the out queue. False if it was not handled
+                and should be queued for further processing.
+        """
+        if isinstance(event, FifoEventShutdown):
+            await self._queue.put((_async_noop, event))
+            return True
+        return False
+
+
+class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase):
+    """Handler that matches events using correlation IDs."""
+
+    def __init__(self) -> None:
+        """
+        Initialize the correlation ID handler.
+        """
+        super().__init__()
+        self._registrations: Dict[
+            UUID,
+            tuple[
+                list[list[type[FifoEventResultWithCID]]],
+                Callable[[FifoEventResultWithCID], Awaitable[bool]],
+                int,
+            ],
+        ]
+        self._registrations = {}
+
+    def register(self,
+                 event: FifoEventWithCID,
+                 expected_cls: Sequence[type[FifoEventResultWithCID]] | Sequence[Sequence[type[FifoEventResultWithCID]]],
+                 callback: Callable[[FifoEventResultWithCID], Awaitable[bool]]) -> None:
+        """
+        Register a callback for an expected event with the same correlation ID.
+
+        Args:
+            event (FifoEventWithCID):
+                The event that was sent and from which the correlation ID is taken.
+
+            expected_cls (Sequence[type[FifoEventResultWithCID]] | Sequence[Sequence[type[FifoEventResultWithCID]]]):
+                One or more sequences of event classes that may be received in order.
+
+            callback (Callable[[FifoEventResultWithCID], Awaitable[bool]]):
+                Asynchronous method to call when the matching event is received.
+                It returns True to continue to the next stage or False to stop
+                processing further events for this correlation ID.
+        """
+        cid = getattr(event, "correlation_id")
+        if expected_cls and isinstance(expected_cls[0], type):  # type: ignore[index]
+            seq = [list(expected_cls)]  # type: ignore[list-item]
+        else:
+            seq = [list(s) for s in expected_cls]  # type: ignore[arg-type]
+        self._registrations[cid] = (seq, callback, 0)
+
+    async def process_event(self, event: FifoEvent) -> bool:
+        if await super().process_event(event):
+            return True
+
+        cid = getattr(event, "correlation_id", None)
+        if cid is None:
+            return False
+
+        registration = self._registrations.get(cid)
+        if registration is None:
+            return False
+
+        seq, callback, idx = registration
+        expected = seq[idx]
+        if not any(isinstance(event, cls) for cls in expected):
+            return False
+
+        async def _wrapper(ev: FifoEvent) -> None:
+            cont = await callback(ev)  # type: ignore[arg-type]
+            if not cont:
+                self._registrations.pop(cid, None)
+
+        if idx + 1 < len(seq):
+            self._registrations[cid] = (seq, callback, idx + 1)
+        else:
+            self._registrations.pop(cid, None)
+
+        await self._queue.put((_wrapper, event))
+        return True

--- a/tests/test_fifo_event_queue_network_async.py
+++ b/tests/test_fifo_event_queue_network_async.py
@@ -7,7 +7,13 @@ from typing import ClassVar
 import pytest
 import trustme
 
-from fifo_dev_common.event.fifo_event import FifoEvent, FifoEventShutdown
+from fifo_dev_common.event.fifo_event import (
+    EErrorCode,
+    FifoEvent,
+    FifoEventResultWithCID,
+    FifoEventShutdown,
+    FifoEventWithCID,
+)
 from fifo_dev_common.event.fifo_event_queue_network import (
     FifoEventQueueNetworkAsyncClient,
     FifoEventQueueNetworkAsyncServer,
@@ -28,6 +34,20 @@ def ensure_fifo_event_dummy_registered():
         FifoEvent.register(DummyEvent)
 
 
+@pytest.fixture(autouse=True)
+def ensure_fifo_event_cid_registered():
+    if DummyCID.event_id not in FifoEvent._registry:
+        FifoEvent.register(DummyCID)
+    if DummyAck.event_id not in FifoEvent._registry:
+        FifoEvent.register(DummyAck)
+    if DummyAckFail.event_id not in FifoEvent._registry:
+        FifoEvent.register(DummyAckFail)
+    if DummyDoneSuccess.event_id not in FifoEvent._registry:
+        FifoEvent.register(DummyDoneSuccess)
+    if DummyDoneFailure.event_id not in FifoEvent._registry:
+        FifoEvent.register(DummyDoneFailure)
+
+
 @FifoEvent.register
 @serializable
 @dataclass(kw_only=True)
@@ -39,6 +59,71 @@ class DummyEvent(FifoEvent):
     def __init__(self, value: int, priority: int = -1):
         super().__init__(priority=priority)
         self.value = value
+
+
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class DummyCID(FifoEventWithCID):
+    """Event carrying a correlation ID."""
+    event_id: ClassVar[int] = 5001
+    value: int = field(metadata={"format": "i"})
+
+    def __init__(self, value: int, correlation_id=None, priority: int = -1):
+        super().__init__(correlation_id=correlation_id, priority=priority)
+        self.value = value
+
+
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class DummyAck(FifoEventResultWithCID):
+    """Acknowledgement event with correlation ID."""
+    event_id: ClassVar[int] = 5002
+
+    def __init__(self, *, correlation_id, priority: int = -1):
+        super().__init__(
+            code=EErrorCode.OK, correlation_id=correlation_id, priority=priority
+        )
+
+
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class DummyAckFail(FifoEventResultWithCID):
+    """Negative acknowledgement with correlation ID."""
+    event_id: ClassVar[int] = 5003
+
+    def __init__(self, *, correlation_id, priority: int = -1):
+        super().__init__(
+            code=EErrorCode.FAIL, correlation_id=correlation_id, priority=priority
+        )
+
+
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class DummyDoneSuccess(FifoEventResultWithCID):
+    """Completion event indicating success."""
+    event_id: ClassVar[int] = 5004
+
+    def __init__(self, *, correlation_id, priority: int = -1):
+        super().__init__(
+            code=EErrorCode.OK, correlation_id=correlation_id, priority=priority
+        )
+
+
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class DummyDoneFailure(FifoEventResultWithCID):
+    """Completion event indicating failure."""
+    event_id: ClassVar[int] = 5005
+
+    def __init__(self, *, correlation_id, priority: int = -1):
+        super().__init__(
+            code=EErrorCode.FAIL, correlation_id=correlation_id, priority=priority
+        )
 
 
 @pytest.mark.asyncio
@@ -112,3 +197,135 @@ async def test_require_tls_without_context_raises(unused_tcp_port: int):
         await FifoEventQueueNetworkAsyncClient.connect(host, port, require_tls=True)
     with pytest.raises(ValueError):
         await FifoEventQueueNetworkAsyncServer.accept(host, port, require_tls=True)
+
+
+@pytest.mark.asyncio
+async def test_cid_handler_consumes_event(unused_tcp_port: int):
+    host = "127.0.0.1"
+    port = unused_tcp_port
+
+    server_task = asyncio.create_task(
+        FifoEventQueueNetworkAsyncServer.accept(host, port)
+    )
+    await asyncio.sleep(0.01)
+
+    client = await FifoEventQueueNetworkAsyncClient.connect(host, port)
+    server = await server_task
+
+    received: asyncio.Future[FifoEventResultWithCID] = asyncio.Future()
+
+    req = DummyCID(value=5)
+
+    async def _cb(ev: FifoEventResultWithCID) -> bool:
+        received.set_result(ev)
+        return True
+
+    client.register(req, [DummyAck], _cb)
+
+    await client.send(req)
+    srv_req = await server._out_queue.get()
+    await server.send(DummyAck(correlation_id=srv_req.correlation_id))
+
+    ack = await asyncio.wait_for(received, 1.0)
+    assert isinstance(ack, DummyAck)
+    assert client._out_queue.empty()
+
+    await client.stop()
+    await server.stop()
+    assert isinstance(await server._out_queue.get(), FifoEventShutdown)
+    assert isinstance(await client._out_queue.get(), FifoEventShutdown)
+    await asyncio.gather(client.join(), server.join())
+
+
+@pytest.mark.asyncio
+async def test_cid_handler_chain_consumes_events(unused_tcp_port: int):
+    host = "127.0.0.1"
+    port = unused_tcp_port
+
+    server_task = asyncio.create_task(
+        FifoEventQueueNetworkAsyncServer.accept(host, port)
+    )
+    await asyncio.sleep(0.01)
+
+    client = await FifoEventQueueNetworkAsyncClient.connect(host, port)
+    server = await server_task
+
+    ack_event = asyncio.Event()
+    done_event = asyncio.Event()
+
+    req = DummyCID(value=6)
+
+    async def _cb(ev: FifoEventResultWithCID) -> bool:
+        if isinstance(ev, DummyAck):
+            ack_event.set()
+            return True
+        done_event.set()
+        return False
+
+    client.register(
+        req,
+        [[DummyAck], [DummyDoneSuccess, DummyDoneFailure]],
+        _cb,
+    )
+
+    await client.send(req)
+    srv_req = await server._out_queue.get()
+    await server.send(DummyAck(correlation_id=srv_req.correlation_id))
+    await asyncio.wait_for(ack_event.wait(), 1.0)
+    await server.send(DummyDoneSuccess(correlation_id=srv_req.correlation_id))
+    await asyncio.wait_for(done_event.wait(), 1.0)
+    assert client._out_queue.empty()
+
+    await client.stop()
+    await server.stop()
+    assert isinstance(await server._out_queue.get(), FifoEventShutdown)
+    assert isinstance(await client._out_queue.get(), FifoEventShutdown)
+    await asyncio.gather(client.join(), server.join())
+
+
+@pytest.mark.asyncio
+async def test_cid_handler_chain_stops_on_failure(unused_tcp_port: int):
+    host = "127.0.0.1"
+    port = unused_tcp_port
+
+    server_task = asyncio.create_task(
+        FifoEventQueueNetworkAsyncServer.accept(host, port)
+    )
+    await asyncio.sleep(0.01)
+
+    client = await FifoEventQueueNetworkAsyncClient.connect(host, port)
+    server = await server_task
+
+    ack_event = asyncio.Event()
+
+    req = DummyCID(value=7)
+
+    async def _cb(ev: FifoEventResultWithCID) -> bool:
+        if isinstance(ev, DummyAck):
+            ack_event.set()
+            return True
+        if isinstance(ev, DummyAckFail):
+            ack_event.set()
+            return False
+        return False
+
+    client.register(
+        req,
+        [[DummyAck, DummyAckFail], [DummyDoneSuccess, DummyDoneFailure]],
+        _cb,
+    )
+
+    await client.send(req)
+    srv_req = await server._out_queue.get()
+    await server.send(DummyAckFail(correlation_id=srv_req.correlation_id))
+    await asyncio.wait_for(ack_event.wait(), 1.0)
+
+    await server.send(DummyDoneSuccess(correlation_id=srv_req.correlation_id))
+    recv = await asyncio.wait_for(client._out_queue.get(), 1.0)
+    assert isinstance(recv, DummyDoneSuccess)
+
+    await client.stop()
+    await server.stop()
+    assert isinstance(await server._out_queue.get(), FifoEventShutdown)
+    assert isinstance(await client._out_queue.get(), FifoEventShutdown)
+    await asyncio.gather(client.join(), server.join())


### PR DESCRIPTION
## Summary
- Add **pre-queue event filtering** in `FifoEventQueueNetworkAsyncMixin` with a callback that decides whether an event is inserted into `_out_queue`.
- Introduce **`FifoEventQueueNetworkAsyncHandlerBase`** and a specialized **Correlation ID handler (`FifoEventQueueNetworkAsyncHandlerCID`)**.
- Support **asynchronous background processing** of acknowledgement and correlation-based events, keeping the network reader path non-blocking.
- Provide a **register API** for declaring expected event sequences:
  - Input event (from which the correlation ID is extracted)
  - Sequence of expected event class types  
  - Async callback to invoke upon reception
- Stop processing automatically when a registered callback returns `False`.
- Ensure handlers respond to **`FifoEventShutdown`** for clean teardown.
- Add **multi-stage correlation flow tests** covering success and failure scenarios.
- Document new handler capabilities in the README.

## Testing
- Verified with `pytest`, including correlation ID flows and shutdown handling.