### PR TITLE
Decouple the CID handler registration logic from `FifoEventQueueNetworkAsyncHandlerBase`

### DIFF
--- a/fifo_dev_common/event/fifo_event_queue_network.py
+++ b/fifo_dev_common/event/fifo_event_queue_network.py
@@ -15,18 +15,14 @@ import threading
 import contextlib
 import ssl
 import hashlib
-from typing import Awaitable, Callable, Optional, Sequence, cast
+from typing import Optional, Sequence, cast
 from fifo_dev_common.event.fifo_event import (
     FifoEvent,
     FifoEventShutdown,
-    FifoEventResultWithCID,
-    FifoEventWithCID,
 )
 from fifo_dev_common.event.fifo_event_protocols import SupportsFifoEventPut
 from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    ExpectedEventClasses,
     FifoEventQueueNetworkAsyncHandlerBase,
-    FifoEventQueueNetworkAsyncHandlerCID,
 )
 from fifo_dev_common.logging.logger import get_logger
 
@@ -314,13 +310,14 @@ class _FifoEventQueueNetworkAsyncMixin:
     
     This mixin contains shared methods for sending events, receiving events, and stopping
     the network connection. It assumes the inheriting class has _reader, _writer, _out_queue,
-    and _task attributes.
+    and _task attributes. A `_handler` attribute may optionally be provided to process
+    incoming events before they are queued.
     """
     _reader: asyncio.StreamReader
     _writer: asyncio.StreamWriter
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _task: asyncio.Task[None]
-    _handler: FifoEventQueueNetworkAsyncHandlerBase
+    _handler: FifoEventQueueNetworkAsyncHandlerBase | None
 
     async def stop(self):
         """
@@ -355,7 +352,9 @@ class _FifoEventQueueNetworkAsyncMixin:
                 logger.error("[%s] Error receiving event: %r", role, type(e))
                 continue
 
-            processed = await self._handler.process_event(event)
+            processed = False
+            if self._handler is not None:
+                processed = await self._handler.process_event(event)
             if not processed:
                 await self._out_queue.put(event)
             if isinstance(event, FifoEventShutdown):
@@ -376,29 +375,6 @@ class _FifoEventQueueNetworkAsyncMixin:
             ConnectionError: If the connection is closed or there's a network error.
         """
         await event.serialize_to_socket_async(self._writer)  # drain handled by serializer
-
-    def register(self,
-                 event: FifoEventWithCID,
-                 expected_cls: ExpectedEventClasses,
-                 callback: Callable[[FifoEventResultWithCID], Awaitable[bool]]):
-        """
-        Register a callback to be invoked when a matching event is received.
-
-        Args:
-            event (FifoEventWithCID):
-                The event being sent that carries a correlation identifier.
-
-            expected_cls (ExpectedEventClasses):
-                Sequence of stages; each stage is either a single event class or a
-                sequence of event classes. Example: [A, [B, C], D].
-
-            callback (Callable[[FifoEventResultWithCID], Awaitable[bool]]):
-                Asynchronous method invoked when the event is received. It returns
-                True to continue waiting for subsequent stages or False to stop
-                processing further events for the correlation ID.
-        """
-
-        self._handler.register(event, expected_cls, callback)
 
     async def put(self, item: FifoEvent) -> None:
         """
@@ -450,15 +426,15 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
             Background asyncio task that continuously receives events from the network
             and places them in the output queue.
 
-        _handler (FifoEventQueueNetworkAsyncHandlerBase):
-            Handler used to process incoming events before queuing.
+        _handler (FifoEventQueueNetworkAsyncHandlerBase | None):
+            Optional handler used to process incoming events before queuing.
     """
     _reader: asyncio.StreamReader
     _writer: asyncio.StreamWriter
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _thread: threading.Thread
     _task: asyncio.Task[None]
-    _handler: FifoEventQueueNetworkAsyncHandlerBase
+    _handler: FifoEventQueueNetworkAsyncHandlerBase | None
 
     def __init__(self,
                  reader: asyncio.StreamReader,
@@ -479,13 +455,13 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
                 Optional priority queue for received events. If None, a new queue is created.
 
             handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
-                Handler used to process incoming events. If None, a default
-                correlation ID handler is used.
+                Handler used to process incoming events. If None, events are
+                queued directly without additional processing.
         """
         self._reader = reader
         self._writer = writer
         self._out_queue = out_queue or asyncio.PriorityQueue()
-        self._handler = handler or FifoEventQueueNetworkAsyncHandlerCID()
+        self._handler = handler
         self._task = asyncio.create_task(self._network_to_queue())
 
     @classmethod
@@ -518,8 +494,8 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
                 Optional priority queue for received events. If None, a new queue is created.
 
             handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
-                Handler used to process incoming events. If None, a default
-                correlation ID handler is used.
+                Handler used to process incoming events. If None, events are
+                queued directly without additional processing.
 
             ssl_ctx (ssl.SSLContext | None, optional):
                 SSL context configured for TLS 1.3. If provided, enables TLS.
@@ -613,7 +589,6 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
 
         # Close writer with a bounded wait
         await _bounded_close_and_wait_closed_writer(self._writer, timeout=3.0, label="client")
-        await self._handler.join()
 
 
 class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, SupportsFifoEventPut):
@@ -651,15 +626,15 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
             Background asyncio task that continuously receives events from the client
             and places them in the output queue.
 
-        _handler (FifoEventQueueNetworkAsyncHandlerBase):
-            Handler used to process incoming events before queuing.
+        _handler (FifoEventQueueNetworkAsyncHandlerBase | None):
+            Optional handler used to process incoming events before queuing.
     """
     _reader: asyncio.StreamReader
     _writer: asyncio.StreamWriter
     _server: asyncio.Server
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _task: asyncio.Task[None]
-    _handler: FifoEventQueueNetworkAsyncHandlerBase
+    _handler: FifoEventQueueNetworkAsyncHandlerBase | None
 
     def __init__(self,
                  reader: asyncio.StreamReader,
@@ -684,14 +659,14 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
                 Optional priority queue for received events. If None, a new queue is created.
 
             handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
-                Handler used to process incoming events. If None, a default
-                correlation ID handler is used.
+                Handler used to process incoming events. If None, events are
+                queued directly without additional processing.
         """
         self._reader = reader
         self._writer = writer
         self._server = server
         self._out_queue = out_queue or asyncio.PriorityQueue()
-        self._handler = handler or FifoEventQueueNetworkAsyncHandlerCID()
+        self._handler = handler
         self._task = asyncio.create_task(self._network_to_queue())
 
     @classmethod
@@ -723,8 +698,8 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
                 Optional priority queue for received events. If None, a new queue is created.
 
             handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
-                Handler used to process incoming events. If None, a default
-                correlation ID handler is used.
+                Handler used to process incoming events. If None, events are
+                queued directly without additional processing.
 
             ssl_ctx (ssl.SSLContext | None, optional):
                 SSL context configured for TLS 1.3. If provided, enables TLS for the server.
@@ -812,4 +787,3 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
 
         # Listener was closed in accept(); now wait for it to finish closing
         await _bounded_wait_closed_server(self._server, timeout=3.0)
-        await self._handler.join()

--- a/fifo_dev_common/event/fifo_event_queue_network_handler.py
+++ b/fifo_dev_common/event/fifo_event_queue_network_handler.py
@@ -42,20 +42,57 @@ class FifoEventQueueNetworkAsyncHandlerBase(ABC):
     """
     Base class for asynchronous network event handlers.
 
-    This handler processes callbacks on a background task so that the network
-    reader is never blocked. Derived classes should implement `register`
-    and may override `process_event`.
+    A handler examines each incoming event and returns ``True`` when the event has
+    been consumed and should not be placed into the caller's queue. Returning
+    ``False`` allows the event to fall through to the queue for further processing
+    by the application.
+    """
+
+    @abstractmethod
+    async def process_event(self, event: FifoEvent) -> bool:
+        """
+        Process an incoming event.
+
+        Args:
+            event (FifoEvent):
+                Incoming event from the network.
+
+        Returns:
+            bool:
+                ``True`` if the event was handled by the handler and should not
+                be queued for application consumption, otherwise ``False``.
+        """
+        raise NotImplementedError
+
+
+class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase):
+    """
+    Handler that matches events using correlation IDs.
+
+    Registered callbacks are executed on a background task so that the network
+    reader is never blocked.
     """
 
     def __init__(self) -> None:
         """
-        Initialize the handler and start the background processing task.
+        Initialize the correlation ID handler and start the background task that
+        dispatches callbacks.
         """
         self._queue: asyncio.Queue[tuple[Callable[[FifoEvent], Awaitable[None]], FifoEvent]]
         self._queue = asyncio.Queue()
         self._task = asyncio.create_task(self._run())
+        self._registrations: Dict[
+            UUID,
+            tuple[
+                NormalizedExpected,
+                Callable[[FifoEventResultWithCID], Awaitable[bool]],
+                int,
+            ],
+        ]
+        self._registrations = {}
 
     async def _run(self) -> None:
+        """Process queued callbacks until a shutdown event is received."""
         while True:
             callback, event = await self._queue.get()
             if isinstance(event, FifoEventShutdown):
@@ -69,72 +106,8 @@ class FifoEventQueueNetworkAsyncHandlerBase(ABC):
                 logger.exception("handler callback failed with unexpected exception")
 
     async def join(self) -> None:
-        """
-        Wait for the handler background task to finish.
-        """
+        """Wait for the background task to finish."""
         await self._task
-
-    @abstractmethod
-    def register(self,
-                 event: FifoEventWithCID,
-                 expected_cls: ExpectedEventClasses,
-                 callback: Callable[[FifoEventResultWithCID], Awaitable[bool]]) -> None:
-        """
-        Register a callback for a specific incoming event.
-
-        Args:
-            event (FifoEventWithCID):
-                Event object being sent and for which a response is expected.
-
-            expected_cls (ExpectedEventClasses):
-                Sequence of stages; each stage is either a single event class or a
-                sequence of event classes. Example: [A, [B, C], D].
-
-            callback (Callable[[FifoEventResultWithCID], Awaitable[bool]]):
-                Asynchronous function invoked when the matching event is received. It
-                returns True to continue to the next stage or False to stop further
-                processing for the correlation ID.
-        """
-
-    async def process_event(self, event: FifoEvent) -> bool:
-        """
-        Process an incoming event.
-
-        Args:
-            event (FifoEvent):
-                Incoming event from the network.
-
-        Returns:
-            bool:
-                True if the event has been processed by the handler and should
-                not be inserted into the out queue. False if it was not handled
-                and should be queued for further processing.
-        """
-        if isinstance(event, FifoEventShutdown):
-            await self._queue.put((_async_noop, event))
-            return False  # Always propagate shutdown event to the out queue
-        return False
-
-
-class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase):
-    """
-    Handler that matches events using correlation IDs.
-    """
-
-    def __init__(self) -> None:
-        """
-        Initialize the correlation ID handler.
-        """
-        super().__init__()
-        self._registrations: Dict[
-            UUID,
-            tuple[
-                NormalizedExpected,
-                Callable[[FifoEventResultWithCID], Awaitable[bool]],
-                int,
-            ],
-        ]
-        self._registrations = {}
 
     def register(self,
                  event: FifoEventWithCID,
@@ -149,25 +122,43 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
 
             expected_cls (ExpectedEventClasses):
                 Sequence of stages; each stage is either a single event class or a
-                sequence of event classes. Example: [A, [B, C], D].
+                sequence of event classes. Example: ``[A, [B, C], D]``.
 
             callback (Callable[[FifoEventResultWithCID], Awaitable[bool]]):
-                Asynchronous method to call when the matching event is received.
-                It returns True to continue to the next stage or False to stop
+                Asynchronous function to invoke when the matching event is received.
+                It returns ``True`` to continue to the next stage or ``False`` to stop
                 processing further events for this correlation ID.
         """
         cid = getattr(event, "correlation_id")
         seq: NormalizedExpected = []
         for stage in expected_cls:
-            if isinstance(stage, type):  # single class -> one-item stage
+            if isinstance(stage, type):
                 seq.append([stage])
-            else:  # sequence of classes
+            else:
                 seq.append([cls for cls in stage])
         self._registrations[cid] = (seq, callback, 0)
 
     async def process_event(self, event: FifoEvent) -> bool:
-        if await super().process_event(event):
-            return True
+        """
+        Process an incoming event.
+
+        If a registration for the event's correlation ID exists and the event
+        matches the next expected class, the associated callback is scheduled on
+        the background task and ``True`` is returned. Otherwise ``False`` is
+        returned so the caller may queue the event for further processing. A
+        ``FifoEventShutdown`` causes the background task to terminate.
+
+        Args:
+            event (FifoEvent):
+                Incoming event from the network.
+
+        Returns:
+            bool: ``True`` if the event was handled by this handler, otherwise
+            ``False``.
+        """
+        if isinstance(event, FifoEventShutdown):
+            await self._queue.put((_async_noop, event))
+            return False
 
         cid = getattr(event, "correlation_id", None)
         if cid is None:

--- a/tests/test_fifo_event_queue_network_async.py
+++ b/tests/test_fifo_event_queue_network_async.py
@@ -19,6 +19,9 @@ from fifo_dev_common.event.fifo_event_queue_network import (
     FifoEventQueueNetworkAsyncClient,
     FifoEventQueueNetworkAsyncServer,
 )
+from fifo_dev_common.event.fifo_event_queue_network_handler import (
+    FifoEventQueueNetworkAsyncHandlerCID,
+)
 from fifo_dev_common.serialization.fifo_serialization import serializable
 
 # pylint: disable=protected-access
@@ -226,7 +229,8 @@ async def test_cid_handler_consumes_event(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    client = await FifoEventQueueNetworkAsyncClient.connect(host, port)
+    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
     received: asyncio.Future[FifoEventResultWithCID] = asyncio.Future()
@@ -237,7 +241,7 @@ async def test_cid_handler_consumes_event(unused_tcp_port: int):
         received.set_result(ev)
         return True
 
-    client.register(req, [DummyAck], _cb)
+    handler.register(req, [DummyAck], _cb)
 
     await client.send(req)
     srv_req = await server._out_queue.get()
@@ -253,6 +257,7 @@ async def test_cid_handler_consumes_event(unused_tcp_port: int):
     assert isinstance(await server._out_queue.get(), FifoEventShutdown)
     assert isinstance(await client._out_queue.get(), FifoEventShutdown)
     await asyncio.gather(client.join(), server.join())
+    await handler.join()
 
 
 @pytest.mark.asyncio
@@ -265,7 +270,8 @@ async def test_cid_handler_chain_consumes_events(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    client = await FifoEventQueueNetworkAsyncClient.connect(host, port)
+    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
     ack_event = asyncio.Event()
@@ -280,7 +286,7 @@ async def test_cid_handler_chain_consumes_events(unused_tcp_port: int):
         done_event.set()
         return False
 
-    client.register(
+    handler.register(
         req,
         [[DummyAck], [DummyDoneSuccess, DummyDoneFailure]],
         _cb,
@@ -300,6 +306,7 @@ async def test_cid_handler_chain_consumes_events(unused_tcp_port: int):
     assert isinstance(await server._out_queue.get(), FifoEventShutdown)
     assert isinstance(await client._out_queue.get(), FifoEventShutdown)
     await asyncio.gather(client.join(), server.join())
+    await handler.join()
 
 
 @pytest.mark.asyncio
@@ -312,7 +319,8 @@ async def test_cid_handler_chain_stops_on_failure(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    client = await FifoEventQueueNetworkAsyncClient.connect(host, port)
+    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
     ack_event = asyncio.Event()
@@ -328,7 +336,7 @@ async def test_cid_handler_chain_stops_on_failure(unused_tcp_port: int):
             return False
         return False
 
-    client.register(
+    handler.register(
         req,
         [[DummyAck, DummyAckFail], [DummyDoneSuccess, DummyDoneFailure]],
         _cb,
@@ -349,3 +357,4 @@ async def test_cid_handler_chain_stops_on_failure(unused_tcp_port: int):
     assert isinstance(await server._out_queue.get(), FifoEventShutdown)
     assert isinstance(await client._out_queue.get(), FifoEventShutdown)
     await asyncio.gather(client.join(), server.join())
+    await handler.join()


### PR DESCRIPTION
## Summary
- Decouple the CID handler registration logic from `FifoEventQueueNetworkAsyncHandlerBase`. It now defines only one abstract method:  
  ```python  
  async def process_event(self, event: FifoEvent) -> bool  
  ```
- Remove `register` from `_FifoEventQueueNetworkAsyncMixin`.
- Remove the automatic call to `handler.join()` during server/client shutdown.  
  The caller is now responsible for joining the handler explicitly.
- Default the handler in server/client to `None` instead of creating a default one.  
  If `None`, events are enqueued directly without additional processing.
- Merge the logic from `FifoEventQueueNetworkAsyncHandlerBase` into `FifoEventQueueNetworkAsyncHandlerCID`.

## Testing
- `pytest -q`