### PR TITLE
Support optional enum serialization format ?E<x>

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ sock_client.close()
 Provides a lightweight, efficient binary serialization framework for Python dataclasses.
 
 - `@serializable`: Decorator to enable serialization/deserialization on dataclasses.
-- Supports scalar types, enums, optional fields, arrays, and fixed-length tuples.
+- Supports scalar types, enums and optional enums, optional fields, arrays, and fixed-length tuples.
 - Uses dataclass `field` metadata (e.g., `format`, `ptype`) for flexible, extensible field definitions.
 - Custom per-field (de)serialization via `field` metadata callables (`serialize`, `deserialize`, `bytelength`).
 - All serialized data is written and read in little-endian byte order, independent of host architecture.
@@ -392,6 +392,7 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `?S`       | **Optional variable-length UTF-8 string** | 1-byte presence flag + 4-byte length + UTF-8 encoded bytes            | -
 | `?S[x]`    | **Optional fixed-length UTF-8 string**    | 1-byte presence flag + UTF-8 encoded, space-padded or truncated to `x` bytes | -
 | `E<x>`     | **Enum stored as integer**           | Stored as `x` (e.g., `B`, `H`, `I`)                                    | `x` must be one of: `b B h H i I`                                     |
+| `?E<x>`    | **Optional enum stored as integer**  | 1-byte presence flag + enum stored as `x`                              | `x` must be one of: `b B h H i I`                                     |
 | `_`        | **Nested object**                    | Nested serialization using `ptype`                                     | Requires `ptype`; equivalent to omitting `format`                     |
 | `?_`       | **Optional nested object**           | 1-byte presence flag + nested serialization if present                 | -                                                                     |
 | `[_]`      | **Array of nested objects**          | 4-byte length prefix + consecutive nested serializations               | -                                                                     |

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -126,9 +126,12 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
           - 'B' — unsigned 1-byte integer
 
       - Enum types serialized as unsigned int:
-          - 'E<I>' — Enum stored as a 4-byte unsigned int.
+          - 'E<x>' — Enum stored as integer type `x` (e.g., 'B', 'H', 'I').
             Requires 'ptype' metadata specifying the Enum class.
-            For now, support only type 'I'
+
+      - Optional Enum types serialized as unsigned int:
+          - '?E<x>' — Optional Enum stored as integer type `x` with presence flag.
+            Requires 'ptype' metadata specifying the Enum class.
 
       - Fixed-size tuple of basic types:
           - 'T<xy...>' where x, y, ... are struct format characters.
@@ -198,7 +201,7 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
             - If the 'format' string is invalid for array, optional, or enum types.
             - If a generic array ('[_]'), optional ('?_'), or optional array ('[?_]') format
               is specified without a 'ptype'.
-            - If an enum format ('E<I>') is used without a 'ptype' Enum class.
+            - If an enum format ('E<x>' or '?E<x>') is used without a 'ptype' Enum class.
             - If neither 'format' nor 'ptype' is provided in the field metadata.
     """
     def _format_error(typename: str, allowed_chars: set[str], suffix: str = "") -> str:
@@ -332,6 +335,24 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
 
         if struct_format == "?S":
             return FieldSpecCompiledOptionalString(name)
+
+        if struct_format.startswith("?E<"):
+            if not (len(struct_format) == 5 and struct_format[4] == ">"):
+                raise ValueError(
+                    "Invalid format: optional enum format must be five characters ending with '>'"
+                )
+
+            inner_type = struct_format[3]
+            supported_enum_ints = {"b", "B", "h", "H", "i", "I"}
+            if inner_type not in supported_enum_ints:
+                raise ValueError(
+                    "Format string for optional enum types only supports integer format characters: b, B, h, H, i, I"
+                )
+
+            if ptype is None:
+                raise ValueError("Type must be provided for optional Enum")
+
+            return FieldSpecCompiledOptionalEnum(name, inner_type, ptype)
 
         if struct_format[0] == "?":
             if not len(struct_format) == 2:
@@ -892,6 +913,73 @@ class FieldSpecCompiledOptional(FieldSpecCompiledBasic):
         if getattr(class_obj, self.name) is None:
             return 1
         return 1 + self._struct_format_byte_length
+
+
+class FieldSpecCompiledOptionalEnum(FieldSpecCompiledOptional):
+    """
+    FieldSpecCompiled subclass for optional Enum fields with a presence flag.
+
+    This class serializes an optional Enum as a single byte presence flag
+    followed by the enum value serialized using the specified struct format.
+    During deserialization, the raw value is converted back to an Enum
+    instance of the provided ``ptype``.
+
+    Attributes:
+        ptype (Type[Enum]):
+            The Enum type used for deserialization and validation.
+    """
+
+    ptype: Type[Enum]
+
+    def __init__(self, name: str, struct_format: str, ptype: Type[Enum]):
+        """
+        Initialize the optional Enum field with its name, struct format, and Enum type.
+
+        Args:
+            name (str):
+                The name of the field.
+
+            struct_format (str):
+                The struct format string defining the binary layout.
+
+            ptype (Type[Enum]):
+                The Enum class used to convert the integer value
+                to the corresponding Enum instance.
+        """
+        super().__init__(name, struct_format)
+        self.ptype = ptype
+
+    def deserialize_from_bytes(self, buffer: bytes, idx: int) -> Tuple[Any, int]:
+        """
+        Deserialize the optional Enum field's value from the buffer starting at index ``idx``.
+
+        Reads the presence flag first. If present, the raw integer value is
+        converted to an Enum instance using ``ptype``.
+
+        Args:
+            buffer (bytes):
+                The buffer containing serialized data.
+
+            idx (int):
+                The starting index in the buffer at which to read data.
+
+        Returns:
+            Tuple[Any, int]:
+                - The deserialized Enum instance or ``None`` if not present.
+                - The updated buffer index after reading the presence flag
+                  and value.
+
+        Raises:
+            Implementation-specific exceptions if deserialization fails.
+        """
+        present = struct.unpack_from("<b", buffer, idx)[0]
+        idx += 1
+
+        if present == 0:
+            return None, idx
+
+        obj, = struct.unpack_from('<' + self.struct_format, buffer, idx)
+        return self.ptype(obj), idx + self._struct_format_byte_length
 
 
 class FieldSpecCompiledArray(FieldSpecCompiledBasic):

--- a/tests/test_fifo_event.py
+++ b/tests/test_fifo_event.py
@@ -298,6 +298,40 @@ def test_enum_serialization_roundtrip():
     assert restored2.priority == 1
 
 
+@FifoEvent.register
+@serializable
+@dataclass(kw_only=True)
+class PriorityEventOptionalEnum(FifoEvent):
+    event_id: ClassVar[int] = 103
+    default_priority: ClassVar[int] = 5
+
+    value: int = field(metadata={"format": "i"})
+    opt_enum: TestEnum | None = field(default=None, metadata={"format": "?E<I>", "ptype": TestEnum})
+
+    def __init__(self, value: int, opt_enum: TestEnum | None = None, priority: int = -1):
+        super().__init__(priority=priority)
+        self.value = value
+        self.opt_enum = opt_enum
+
+
+def test_optional_enum_serialization_roundtrip():
+    event = PriorityEventOptionalEnum(42, opt_enum=TestEnum.B, priority=99)
+    blob = event.to_bytes()
+    restored = FifoEvent.from_bytes(blob)
+    assert isinstance(restored, PriorityEventOptionalEnum)
+    assert restored.value == 42
+    assert restored.opt_enum == TestEnum.B
+    assert restored.priority == 99
+
+    event2 = PriorityEventOptionalEnum(100, opt_enum=None, priority=1)
+    blob2 = event2.to_bytes()
+    restored2 = FifoEvent.from_bytes(blob2)
+    assert isinstance(restored2, PriorityEventOptionalEnum)
+    assert restored2.value == 100
+    assert restored2.opt_enum is None
+    assert restored2.priority == 1
+
+
 def test_registry_thread_safety() -> None:
     results: list[bool] = []
     def register_event():

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -57,6 +57,32 @@ def test_serialize_enum(fmt: str):
     assert deserialized_test.b == TestEnum.B
 
 
+@pytest.mark.parametrize("fmt", ["?E<b>", "?E<B>", "?E<h>", "?E<H>", "?E<i>", "?E<I>"])
+def test_serialize_optional_enum(fmt: str):
+    @serializable
+    @dataclass
+    class _TestSerializeOptEnum(FifoSerializable):
+        a: TestEnum | None = field(metadata={"format": fmt, "ptype": TestEnum})
+        b: TestEnum | None = field(metadata={"format": fmt, "ptype": TestEnum})
+
+    test = _TestSerializeOptEnum(TestEnum.A, None)
+
+    byte_size = test.serialized_byte_size()
+    struct_size = struct.calcsize('<' + fmt[3])
+    expected_size = struct_size + 2  # present field + None field
+    assert byte_size == expected_size
+
+    buffer = bytearray(byte_size)
+
+    test.serialize_to_bytes(buffer, 0)
+
+    deserialized_test, _ = _TestSerializeOptEnum.deserialize_from_bytes(buffer, 0)
+
+    assert type(deserialized_test.a) == TestEnum
+    assert deserialized_test.a == TestEnum.A
+    assert deserialized_test.b is None
+
+
 
 @serializable
 @dataclass
@@ -414,6 +440,11 @@ def test_super_combo():
     ("E<_>",  None, "Format string for enum types only supports integer format characters: b, B, h, H, i, I"),
     ("E<d>",  None, "Format string for enum types only supports integer format characters: b, B, h, H, i, I"),
     ("E<I>",  None, "Type must be provided for Enum"),
+    ("?E<",  None, "Invalid format: optional enum format must be five characters ending with '>'"),
+    ("?E<>",  None, "Invalid format: optional enum format must be five characters ending with '>'"),
+    ("?E<_>", None, "Format string for optional enum types only supports integer format characters: b, B, h, H, i, I"),
+    ("?E<d>", None, "Format string for optional enum types only supports integer format characters: b, B, h, H, i, I"),
+    ("?E<I>", None, "Type must be provided for optional Enum"),
 
     ("T<",   None, "Invalid format: tuple format must start with 'T<', end with '>', and contain at least one format character"),
     ("T<>",  None, "Invalid format: tuple format must start with 'T<', end with '>', and contain at least one format character"),


### PR DESCRIPTION
## Summary
- add `?E<x>` format for optional enum serialization
- document optional enum support in README and docstrings
- test optional enum round-trips and error cases

## Testing
- `pytest`