### PR TITLE
Refactor asyncio event queue clients into a shared connector with serial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ It provides the following for runtime type checks and casting, docstring parsing
 - `recv_all(sock, n)`: Efficiently receive exactly `n` bytes from a socket-like object supporting `recv_into()`.
 - `class FifoEvent`: Base class for binary-serializable events, with factory deserialization and class registration for cross-system use.
 - `class FifoEventQueueForwarderMpToAsync`: Bridges multiprocessing and asyncio event queues via a background thread.
+- `class FifoEventQueueConnectorAsyncClient`: Shared asyncio client helpers for stream-based transports.
 - `class FifoEventQueueNetworkAsyncClient` / `class FifoEventQueueNetworkAsyncServer`: Asyncio-based network communication for FifoEvent objects over TCP with optional TLS 1.3 encryption.
-- `class FifoEventQueueNetworkAsyncHandlerCID`: Correlation-ID request/response helpers via `register_cid_template`, `send_and_wait`, and `send_in_background`; outcomes use `FifoEventCIDOutcome`.
+- `class FifoEventQueueSerialAsyncClient`: Asyncio serial communication for environments exposing serial connections via `serial_asyncio`.
+- `class FifoEventQueueConnectorAsyncHandlerCID`: Correlation-ID request/response helpers via `register_cid_template`, `send_and_wait`, and `send_in_background`; outcomes use `FifoEventCIDOutcome`.
 - `class FifoProcessManager`: Manager for running workers in separate OS processes with interprocess communication. Abstracts process creation, startup, and shutdown while bridging multiprocessing queues with asyncio. Supports both async and sync worker callbacks, with correlation ID tracking for request/response workflows.
 - `get_logger()`: Returns a logger instance with `.trace()` support for fine-grained debugging. Registers a custom TRACE level and logger class.
 - `class FifoRefreshableValue`: Lock-free cache for asynchronously refreshed values with explicit state transitions and immutable snapshots.
@@ -44,7 +46,9 @@ It provides the following for runtime type checks and casting, docstring parsing
   - [fifo_serialization](#fifo_dev_commonserializationfifo_serialization)
   - [fifo_event](#fifo_dev_commoneventfifo_event)
   - [fifo_event_queue_forwarder](#fifo_dev_commoneventfifo_event_queue_forwarder)
+  - [fifo_event_queue_connector](#fifo_dev_commoneventfifo_event_queue_connector)
   - [fifo_event_queue_network](#fifo_dev_commoneventfifo_event_queue_network)
+  - [fifo_event_queue_serial](#fifo_dev_commoneventfifo_event_queue_serial)
   - [fifo_process_manager](#fifo_dev_commonprocessutilsfifo_process_manager)
   - [logger](#fifo_dev_commonlogginglogger)
   - [fifo_refreshable_value](#fifo_dev_commonstatefifo_refreshable_value)
@@ -823,9 +827,22 @@ if __name__ == "__main__":
 
 ---
 
+### `fifo_dev_common.event.fifo_event_queue_connector`
+
+Reusable asyncio components shared by the transport-specific clients.
+
+- `FifoEventQueueConnectorAsyncClient`: manages the background reader task,
+  output queue, and graceful shutdown for any ``StreamReader``/``StreamWriter`` pair.
+- `FifoEventQueueConnectorAsyncHandlerCID`: correlation-ID helper powering
+  the higher-level network and serial helpers.
+
+---
+
 ### `fifo_dev_common.event.fifo_event_queue_network`
 
-Asyncio-based TCP transport for `FifoEvent` objects, with optional TLS 1.3 encryption.
+Asyncio-based TCP transport for `FifoEvent` objects, built on top of
+`asyncio.open_connection()` / `asyncio.start_server()` with optional TLS 1.3
+encryption.
 
 - `FifoEventQueueNetworkAsyncClient`: sends events immediately; receives events in a background task and enqueues them in a local `asyncio.PriorityQueue`.
 - `FifoEventQueueNetworkAsyncServer`: accepts **exactly one** client at a time (additional clients are rejected until the connection closes); sends events immediately and receives events in a background task, enqueuing them in a local `asyncio.PriorityQueue`.
@@ -924,6 +941,15 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+---
+
+### `fifo_dev_common.event.fifo_event_queue_serial`
+
+Asyncio serial transport built on top of `serial_asyncio.open_serial_connection()`.
+
+- `FifoEventQueueSerialAsyncClient`: leverages the shared connector base to reuse
+  the same API as the TCP client while targeting serial links.
 
 ---
 

--- a/fifo_dev_common/event/fifo_event_cid_request_manager.py
+++ b/fifo_dev_common/event/fifo_event_cid_request_manager.py
@@ -9,8 +9,8 @@ from fifo_dev_common.event.fifo_event import (
     FifoEventWithCID,
     FifoEventResultWithCID,
 )
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
     ExpectedEventClasses,
 )
 from fifo_dev_common.state.fifo_refreshable_value import FifoRefreshableValue
@@ -39,19 +39,19 @@ class FifoEventCIDRefreshManager:
     cache updates.
 
     Args:
-        handler (FifoEventQueueNetworkAsyncHandlerCID):
+        handler (FifoEventQueueConnectorAsyncHandlerCID):
             CID-capable handler that manages per-CID stage tracking and executes the
             registered success/failure callbacks.
     """
 
-    _handler: FifoEventQueueNetworkAsyncHandlerCID
+    _handler: FifoEventQueueConnectorAsyncHandlerCID
 
-    def __init__(self, handler: FifoEventQueueNetworkAsyncHandlerCID) -> None:
+    def __init__(self, handler: FifoEventQueueConnectorAsyncHandlerCID) -> None:
         """
         Initialize a refresh manager bound to a CID-aware handler.
 
         Args:
-            handler (FifoEventQueueNetworkAsyncHandlerCID):
+            handler (FifoEventQueueConnectorAsyncHandlerCID):
                 CID-capable handler that manages per-CID stage tracking and executes the
                 registered success/failure callbacks.
         """

--- a/fifo_dev_common/event/fifo_event_queue_connector.py
+++ b/fifo_dev_common/event/fifo_event_queue_connector.py
@@ -1,0 +1,321 @@
+"""
+Common asyncio connector utilities for FIFO event queues.
+
+The module consolidates the shared asyncio logic previously embedded in the TCP client so it can
+be reused by multiple transports (network, serial, etc.).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Final
+
+from fifo_dev_common.event.fifo_event import FifoEvent, FifoEventShutdown
+from fifo_dev_common.event.fifo_event_protocols import SupportsFifoEventPut, SendStatus
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerBase,
+)
+from fifo_dev_common.logging.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def _bounded_close_and_wait_closed_writer(
+    writer: asyncio.StreamWriter,
+    *,
+    timeout: float,
+    label: str,
+) -> None:
+    """
+    Close an asyncio StreamWriter and wait for it to finish closing with timeout protection.
+
+    The helper mirrors the previous network implementation but is shared across
+    connector types. It performs a graceful shutdown of the writer by calling
+    close() and then waiting for wait_closed() to complete while bounding the
+    wait time.
+
+    Args:
+        writer (asyncio.StreamWriter):
+            The asyncio writer to close and wait for.
+
+        timeout (float):
+            Maximum seconds to wait for wait_closed().
+
+        label (str):
+            Label used in log messages for additional context.
+    """
+
+    peer: Final[tuple[str, int] | None] = writer.get_extra_info("peername")
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[%s] wait_closed() timed out after %.1fs (peer=%s); proceeding.",
+            label,
+            timeout,
+            peer,
+        )
+    except (BrokenPipeError, ConnectionResetError) as exc:
+        logger.debug(
+            "[%s] wait_closed() benign connection error: %r (peer=%s); proceeding.",
+            label,
+            exc,
+            peer,
+        )
+
+
+class _FifoEventQueueConnectorAsyncMixin:
+    """
+    Mixin with common asyncio connector behaviour.
+
+    The mixin encapsulates the logic for sending and receiving FifoEvent instances
+    over an asyncio stream pair. It assumes subclasses provide _reader, _writer,
+    _out_queue and _task attributes as well as an optional handler used to
+    intercept events.
+    """
+
+    _reader: asyncio.StreamReader
+    _writer: asyncio.StreamWriter
+    _out_queue: asyncio.PriorityQueue[FifoEvent]
+    _task: asyncio.Task[None]
+    _handler: FifoEventQueueConnectorAsyncHandlerBase | None
+
+    async def stop(self) -> None:
+        """
+        Signal the connection to stop by sending a shutdown event.
+
+        This method sends a FifoEventShutdown event which will cause the background
+        connector-to-queue task to terminate after processing the shutdown signal.
+        Call join() after this method to wait for the actual shutdown to complete.
+
+        Raises:
+            ConnectionError: If the connection is already closed or there is a transport error.
+        """
+
+        await self.send(FifoEventShutdown())
+
+    async def _network_to_queue(self) -> None:
+        """
+        Background task that continuously receives events from the connector and enqueues them.
+
+        This method runs in a background asyncio task and continuously deserializes events
+        from the connector stream. If a handler is configured, incoming events are processed
+        through the handler's process_incoming_event() method, which may modify or suppress
+        them. Only non-None events are placed into the output queue. The task terminates when
+        a FifoEventShutdown event is received.
+
+        Note:
+            When a FifoEventShutdown is received, process_incoming_event() is still invoked so the
+            handler can observe it, but its return value is ignored. The original shutdown event is
+            always enqueued exactly once.
+
+        Handler errors are logged; the failing event is discarded (except shutdown, which still
+        propagates).
+
+        Raises:
+            ConnectionError: If the connector stream is lost during operation.
+        """
+
+        while True:
+            try:
+                event = await FifoEvent.deserialize_from_stream_async(self._reader)
+            except (RuntimeError, TypeError, ValueError) as exc:
+                role = "client" if "Client" in type(self).__name__ else "server"
+                logger.error("[%s] Error receiving event: %r", role, type(exc))
+                continue
+
+            if self._handler is not None:
+                try:
+                    event_to_enqueue = await self._handler.process_incoming_event(event)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    role = "client" if "Client" in type(self).__name__ else "server"
+                    logger.error(
+                        "[%s] process_incoming_event handler failed. Discarding event.",
+                        role,
+                    )
+                    event_to_enqueue = None
+
+                if not isinstance(event, FifoEventShutdown):
+                    if event_to_enqueue is None:
+                        continue
+                    event = event_to_enqueue
+
+            await self._out_queue.put(event)
+            if isinstance(event, FifoEventShutdown):
+                break
+
+    async def send(self, event: FifoEvent) -> SendStatus:
+        """
+        Send a FifoEvent over the connector.
+
+        This method processes the event through the handler's process_outgoing_event() method (if a
+        handler is configured), which may modify or suppress the event. If the handler returns a
+        non-None event, it is serialized and sent over the connector. The event is automatically
+        flushed to ensure delivery.
+
+        If the write completes without raising an exception, the handler's process_sent_event()
+        method is invoked (if configured) with the event that has been successfully sent.
+
+        Note:
+            When a FifoEventShutdown is sent, process_outgoing_event() is still invoked so the
+            handler can observe it, but its return value is ignored. The original shutdown event is
+            always sent instead of the return value.
+
+        Handler errors are logged; the failing event is discarded (except shutdown, which is still
+        sent).
+
+        Args:
+            event (FifoEvent):
+                The event to send over the connector.
+
+        Returns:
+            SendStatus:
+                SendStatus.SENT if the event was written (or shutdown propagated).
+                SendStatus.SUPPRESSED if the handler suppressed the event (returned None for a
+                non-shutdown event) or if a handler hook failed and the event was discarded.
+
+        Raises:
+            ConnectionError: If the connector is closed or a transport error occurs.
+        """
+
+        if self._handler is not None:
+            try:
+                event_to_send = await self._handler.process_outgoing_event(event)
+            except Exception:  # pylint: disable=broad-exception-caught
+                role = "client" if "Client" in type(self).__name__ else "server"
+                logger.error(
+                    "[%s] process_outgoing_event handler failed. Discarding event.",
+                    role,
+                )
+                event_to_send = None
+
+            if not isinstance(event, FifoEventShutdown):
+                if event_to_send is None:
+                    return SendStatus.SUPPRESSED
+                event = event_to_send
+
+        await event.serialize_to_stream_async(self._writer)
+
+        if self._handler is not None:
+            try:
+                await self._handler.process_sent_event(event)
+            except Exception:  # pylint: disable=broad-exception-caught
+                role = "client" if "Client" in type(self).__name__ else "server"
+                logger.error(
+                    "[%s] process_sent_event handler failed.",
+                    role,
+                )
+
+        return SendStatus.SENT
+
+    async def put(self, item: FifoEvent) -> None:
+        """
+        Queue-like alias that forwards to send().
+
+        Args:
+            item (FifoEvent):
+                The event to enqueue for sending.
+        """
+
+        await self.send(item)
+
+
+class FifoEventQueueConnectorAsyncClient(
+    _FifoEventQueueConnectorAsyncMixin,
+    SupportsFifoEventPut,
+):
+    """
+    Base asyncio client shared by connector implementations.
+
+    Subclasses provide the logic that creates the StreamReader/StreamWriter pair, typically via a
+    classmethod like `connect()`. Once instantiated the client mirrors the behaviour of the previous
+    network-only implementation: outbound events are written immediately when `send()` is called,
+    while inbound events are received in a background task and queued in `_out_queue`.
+
+    Attributes:
+        _reader (asyncio.StreamReader):
+            Asyncio stream reader used to pull serialized events from the transport.
+
+        _writer (asyncio.StreamWriter):
+            Asyncio stream writer used to push serialized events to the transport.
+
+        _out_queue (asyncio.PriorityQueue[FifoEvent]):
+            Priority queue populated with incoming events in the order they are received.
+
+        _task (asyncio.Task[None]):
+            Background task created in `__init__` that runs `_network_to_queue()`.
+
+        _handler (FifoEventQueueConnectorAsyncHandlerBase | None):
+            Optional handler invoked for incoming, outgoing, and sent events.
+    """
+
+    _reader: asyncio.StreamReader
+    _writer: asyncio.StreamWriter
+    _out_queue: asyncio.PriorityQueue[FifoEvent]
+    _task: asyncio.Task[None]
+    _handler: FifoEventQueueConnectorAsyncHandlerBase | None
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        out_queue: asyncio.PriorityQueue[FifoEvent] | None,
+        handler: FifoEventQueueConnectorAsyncHandlerBase | None = None,
+    ) -> None:
+        """
+        Initialize a connector client with existing asyncio stream objects.
+
+        Args:
+            reader (asyncio.StreamReader):
+                Stream reader that supplies serialized events.
+
+            writer (asyncio.StreamWriter):
+                Stream writer that receives serialized events.
+
+            out_queue (asyncio.PriorityQueue[FifoEvent] | None):
+                Optional priority queue to receive inbound events. When `None`, a fresh queue is
+                created so the client owns its own buffer.
+
+            handler (FifoEventQueueConnectorAsyncHandlerBase | None, optional):
+                Optional handler invoked during event ingress/egress.
+        """
+        self._reader = reader
+        self._writer = writer
+        self._out_queue = out_queue or asyncio.PriorityQueue()
+        self._handler = handler
+        self._task = asyncio.create_task(self._network_to_queue())
+
+    async def join(self, timeout: float = 5.0) -> None:
+        """
+        Wait for the connector to finish shutting down and close the writer.
+
+        This method waits for the background receive task to finish, cancelling it if the
+        timeout elapses. After the task completes (or is cancelled), the writer is closed using
+        _bounded_close_and_wait_closed_writer() to ensure a graceful shutdown.
+
+        Args:
+            timeout (float):
+                Maximum seconds to wait for the receive task.
+
+        Raises:
+            ConnectionError: If the connector encounters an error while shutting down.
+        """
+
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[client] join() timed out after %.1fs; cancelling background task.",
+                timeout,
+            )
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+        await _bounded_close_and_wait_closed_writer(
+            self._writer,
+            timeout=3.0,
+            label="client",
+        )

--- a/fifo_dev_common/event/fifo_event_queue_connector_handler.py
+++ b/fifo_dev_common/event/fifo_event_queue_connector_handler.py
@@ -55,16 +55,16 @@ OnDoneCallback: TypeAlias = Callable[
     Awaitable[None]
 ]
 
-class FifoEventQueueNetworkAsyncHandlerBase(ABC):
+class FifoEventQueueConnectorAsyncHandlerBase(ABC):
     """
-    Base class for asynchronous network event handlers.
+    Base class for asynchronous connector event handlers.
 
     Handlers can intercept and process events in three phases:
 
-    - Incoming events (from the network, before enqueuing):
+    - Incoming events (from the connector, before enqueuing):
       Return the event (possibly modified) to enqueue, or None to suppress.
 
-    - Outgoing events (before sending to the network):
+    - Outgoing events (before sending to the connector):
       Return the event (possibly modified) to send, or None to suppress sending.
 
     - Sent events (after the event has been successfully written and flushed):
@@ -87,12 +87,12 @@ class FifoEventQueueNetworkAsyncHandlerBase(ABC):
         """
         Process an incoming event before it is enqueued.
 
-        Called when an event is received from the network and before it is added to the 
+        Called when an event is received from the connector and before it is added to the
         outgoing queue.
 
         Args:
             event (FifoEvent):
-                Incoming event from the network.
+                Incoming event from the connector.
 
         Returns:
             FifoEvent | None:
@@ -103,13 +103,13 @@ class FifoEventQueueNetworkAsyncHandlerBase(ABC):
     @abstractmethod
     async def process_outgoing_event(self, event: FifoEvent) -> FifoEvent | None:
         """
-        Process an outgoing event before it is sent over the network.
+        Process an outgoing event before it is sent over the connector.
 
-        Called when an event is about to be serialized and written to the network.
+        Called when an event is about to be serialized and written to the connector.
 
         Args:
             event (FifoEvent):
-                Outgoing event to be sent over the network.
+                Outgoing event to be sent over the connector.
 
         Returns:
             FifoEvent | None:
@@ -120,7 +120,7 @@ class FifoEventQueueNetworkAsyncHandlerBase(ABC):
     @abstractmethod
     async def process_sent_event(self, event: FifoEvent) -> None:
         """
-        Called after an outgoing event has been successfully sent over the network.
+        Called after an outgoing event has been successfully sent over the connector.
 
         Implementations can perform post-send bookkeeping (logging, metrics,
         triggering side-effects, etc.). This hook is for notification only and
@@ -133,7 +133,7 @@ class FifoEventQueueNetworkAsyncHandlerBase(ABC):
         raise NotImplementedError  # pragma: no cover
 
 
-class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase):
+class FifoEventQueueConnectorAsyncHandlerCID(FifoEventQueueConnectorAsyncHandlerBase):
     """
     Correlation ID-based event handler for managing request/response workflows.
 
@@ -156,7 +156,7 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
 
     Example:
         ```python
-        handler = FifoEventQueueNetworkAsyncHandlerCID()
+        handler = FifoEventQueueConnectorAsyncHandlerCID()
 
         # 1) Define the contract once at startup
         async def on_ok(ev: FifoEventWithCID | FifoEventResultWithCID) -> None: ...
@@ -177,7 +177,7 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
     Thread Safety:
         This handler is thread-safe and designed for concurrent use in asyncio environments.
         Callbacks are executed sequentially on a dedicated background task to prevent
-        blocking the network reader.
+        blocking the connector reader.
     """
 
     class QueueItemKind(Enum):
@@ -279,22 +279,22 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
             try:
                 if kind is self.QueueItemKind.SEND:
                     cb, ev = cast(
-                        FifoEventQueueNetworkAsyncHandlerCID.QueuePayloadSend, payload
+                        FifoEventQueueConnectorAsyncHandlerCID.QueuePayloadSend, payload
                     )
                     await cb(ev)
                 elif kind is self.QueueItemKind.SENT:
                     cb, ev = cast(
-                        FifoEventQueueNetworkAsyncHandlerCID.QueuePayloadSent, payload
+                        FifoEventQueueConnectorAsyncHandlerCID.QueuePayloadSent, payload
                     )
                     await cb(ev)
                 elif kind is self.QueueItemKind.OUTCOME:
                     cb_outcome, outcome, req = cast(
-                        FifoEventQueueNetworkAsyncHandlerCID.QueuePayloadOutcome, payload
+                        FifoEventQueueConnectorAsyncHandlerCID.QueuePayloadOutcome, payload
                     )
                     await cb_outcome(outcome, req)
                 elif kind is self.QueueItemKind.LISTENER:
                     cb_listener, ev_any = cast(
-                        FifoEventQueueNetworkAsyncHandlerCID.QueuePayloadListener, payload
+                        FifoEventQueueConnectorAsyncHandlerCID.QueuePayloadListener, payload
                     )
                     await cb_listener(ev_any)
                 else:  # pragma: no cover - defensive branch
@@ -494,7 +494,7 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
 
         Args:
             event (FifoEvent):
-                Outgoing event to be sent over the network.
+                Outgoing event to be sent over the connector.
 
         Returns:
             FifoEvent | None:
@@ -508,7 +508,7 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
             return event
 
         # Find a template for this event class (supporting inheritance chains)
-        template: FifoEventQueueNetworkAsyncHandlerCID.TemplateContent | None = None
+        template: FifoEventQueueConnectorAsyncHandlerCID.TemplateContent | None = None
         for cls in type(event).mro():  # search MRO for a registered base class
             if cls in self._templates:
                 template = self._templates[cls]
@@ -538,10 +538,10 @@ class FifoEventQueueNetworkAsyncHandlerCID(FifoEventQueueNetworkAsyncHandlerBase
 
     async def process_sent_event(self, event: FifoEvent) -> None:
         """
-        Observe an event after it has been successfully sent over the network.
+        Observe an event after it has been successfully sent over the connector.
 
         This hook mirrors `process_outgoing_event()` but runs only after the
-        event was written and flushed on the socket. For CID-capable events that
+        event was written and flushed on the transport. For CID-capable events that
         match a registered template, it schedules the optional `on_sent`
         callback on the internal dispatcher task.
 

--- a/fifo_dev_common/event/fifo_event_queue_network.py
+++ b/fifo_dev_common/event/fifo_event_queue_network.py
@@ -11,18 +11,20 @@ Asyncio-based TCP transport for `FifoEvent` objects, with optional TLS 1.3 encry
 """
 
 import asyncio
-import threading
 import contextlib
 import ssl
 import hashlib
 from typing import Optional, Sequence, cast
-from fifo_dev_common.event.fifo_event import (
-    FifoEvent,
-    FifoEventShutdown,
-)
+
+from fifo_dev_common.event.fifo_event import FifoEvent
 from fifo_dev_common.event.fifo_event_protocols import SupportsFifoEventPut, SendStatus
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerBase,
+from fifo_dev_common.event.fifo_event_queue_connector import (
+    FifoEventQueueConnectorAsyncClient,
+    _FifoEventQueueConnectorAsyncMixin,
+    _bounded_close_and_wait_closed_writer,
+)
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerBase,
 )
 from fifo_dev_common.logging.logger import get_logger
 
@@ -118,46 +120,6 @@ def make_client_tls_context(cafile: str,
         ctx.load_cert_chain(certfile=certfile, keyfile=keyfile)
 
     return ctx
-
-
-# ---------- helpers (close/wait bounded, no broad except) ----------
-
-async def _bounded_close_and_wait_closed_writer(writer: asyncio.StreamWriter,
-                                                *,
-                                                timeout: float,
-                                                label: str) -> None:
-    """
-    Close an asyncio StreamWriter and wait for it to finish closing with timeout protection.
-
-    This function performs a graceful shutdown of a StreamWriter by calling close() and then
-    waiting for wait_closed() to complete. It includes timeout protection and logs only
-    benign connection errors that commonly occur during shutdown.
-
-    Args:
-        writer (asyncio.StreamWriter):
-            The asyncio StreamWriter to close and wait for.
-
-        timeout (float):
-            Maximum time in seconds to wait for the writer to close completely.
-
-        label (str):
-            A label for logging purposes to identify which connection is being closed.
-
-    Raises:
-        No exceptions are raised; all errors are logged and the function proceeds.
-    """
-    peer: tuple[str, int] | None = writer.get_extra_info("peername")
-    writer.close()
-    try:
-        await asyncio.wait_for(writer.wait_closed(), timeout=timeout)
-    except asyncio.TimeoutError:
-        logger.warning(
-            "[%s] wait_closed() timed out after %.1fs (peer=%s); proceeding.", label, timeout, peer
-        )
-    except (BrokenPipeError, ConnectionResetError) as e:
-        logger.debug(
-            "[%s] wait_closed() benign socket error: %r (peer=%s); proceeding.", label, e, peer
-        )
 
 
 async def _bounded_wait_closed_server(server: asyncio.base_events.Server,
@@ -298,167 +260,7 @@ def _log_tls_peer(writer: asyncio.StreamWriter, role: str) -> None:
     logger.info("[%s] TLS peer: CN=%s, fpSHA256=%s, notAfter=%s, issuer=%s",
                 role, cn or "?", fp or "?", not_after or "?", issuer or "?")
 
-
-# -----------------------------------
-# Base mixin for common functionality
-# -----------------------------------
-
-
-class _FifoEventQueueNetworkAsyncMixin:
-    """
-    Mixin class providing common functionality for both client and server network classes.
-    
-    This mixin contains shared methods for sending events, receiving events, and stopping
-    the network connection. It assumes the inheriting class has _reader, _writer, _out_queue,
-    and _task attributes. A `_handler` attribute may optionally be provided to process
-    incoming events before they are queued.
-    """
-    _reader: asyncio.StreamReader
-    _writer: asyncio.StreamWriter
-    _out_queue: asyncio.PriorityQueue[FifoEvent]
-    _task: asyncio.Task[None]
-    _handler: FifoEventQueueNetworkAsyncHandlerBase | None
-
-    async def stop(self):
-        """
-        Signal the connection to stop by sending a shutdown event.
-
-        This method sends a FifoEventShutdown event which will cause the background
-        network-to-queue task to terminate after processing the shutdown signal.
-        Call join() after this method to wait for the actual shutdown to complete.
-
-        Raises:
-            ConnectionError: If the connection is already closed or there's a network error.
-        """
-        await self.send(FifoEventShutdown())
-
-    async def _network_to_queue(self):
-        """
-        Background task that continuously receives events from the network and enqueues them.
-
-        This method runs in a background asyncio task and continuously deserializes events
-        from the network stream. If a handler is configured, incoming events are processed
-        through the handler's process_incoming_event() method, which may modify or suppress
-        them. Only non-None events are placed into the output queue. The task terminates when
-        a FifoEventShutdown event is received.
-
-        Note:
-            When a FifoEventShutdown is received, process_incoming_event() is still invoked so the
-            handler can observe it, but its return value is ignored. The original shutdown event is
-            always enqueued exactly once.
-
-        Handler errors are logged; the failing event is discarded (except shutdown, which still
-        propagates).
-
-        Raises:
-            ConnectionError: If the network connection is lost during operation.
-        """
-        while True:
-            try:
-                event = await FifoEvent.deserialize_from_stream_async(self._reader)
-            except (RuntimeError, TypeError, ValueError) as e:
-                role = "client" if "Client" in type(self).__name__ else "server"
-                logger.error("[%s] Error receiving event: %r", role, type(e))
-                continue
-
-            if self._handler is not None:
-                try:
-                    event_to_enqueue = await self._handler.process_incoming_event(event)
-                except Exception: # pylint: disable=broad-exception-caught
-                    # Broad exception to catch handler errors so a faulty callback can't break the
-                    # receive background pipeline.
-                    role = "client" if "Client" in type(self).__name__ else "server"
-                    logger.error("[%s] process_incoming_event handler failed. Discarding event.",
-                                 role)
-                    event_to_enqueue = None
-
-                if not isinstance(event, FifoEventShutdown):
-                    if event_to_enqueue is None:
-                        continue
-                    event = event_to_enqueue
-
-            await self._out_queue.put(event)
-            if isinstance(event, FifoEventShutdown):
-                break
-
-    async def send(self, event: FifoEvent) -> SendStatus:
-        """
-        Send a FifoEvent over the network connection.
-
-        This method processes the event through the handler's process_outgoing_event() method (if a
-        handler is configured), which may modify or suppress the event. If the handler returns a
-        non-None event, it is serialized and sent over the network connection. The event is
-        automatically flushed to ensure delivery.
-
-        If the write completes without raising an exception, the handler's `process_sent_event()`
-        method is invoked (if configured) with the event that has been successfully sent.
-
-        Note:
-            When a FifoEventShutdown is sent, process_outgoing_event() is still invoked so the
-            handler can observe it, but its return value is ignored. The original shutdown event is
-            always sent instead of the return value.
-
-        Handler errors are logged; the failing event is discarded (except shutdown, which is still
-        sent).
-
-        Args:
-            event (FifoEvent):
-                The event to send over the network connection.
-
-        Returns:
-            SendStatus:
-                `SendStatus.SENT` if the event was written (or shutdown propagated).
-                `SendStatus.SUPPRESSED` if the handler suppressed the event (returned None for a
-                non-shutdown event) or if a handler hook failed and the event was discarded.
-
-        Raises:
-            ConnectionError: If the connection is closed or a network error occurs.
-        """
-        if self._handler is not None:
-            try:
-                event_to_send = await self._handler.process_outgoing_event(event)
-            except Exception: # pylint: disable=broad-exception-caught
-                # Broad exception to catch handler errors so a faulty callback can't break the send
-                # pipeline; the event is discarded and treated as suppressed.
-                role = "client" if "Client" in type(self).__name__ else "server"
-                logger.error("[%s] process_outgoing_event handler failed. Discarding event.", role)
-                event_to_send = None
-
-            if not isinstance(event, FifoEventShutdown):
-                if event_to_send is None:
-                    return SendStatus.SUPPRESSED
-                event = event_to_send
-
-        await event.serialize_to_stream_async(self._writer)  # drain handled by serializer
-
-        if self._handler is not None:
-            try:
-                await self._handler.process_sent_event(event)
-            except Exception: # pylint: disable=broad-exception-caught
-                # Broad exception to catch handler errors so a faulty callback can't break the send
-                # pipeline.
-                role = "client" if "Client" in type(self).__name__ else "server"
-                logger.error("[%s] process_sent_event handler failed.", role)
-
-        return SendStatus.SENT
-
-    async def put(self, item: FifoEvent) -> None:
-        """
-        Queue-like alias for send.
-
-        Provides compatibility with asyncio.PriorityQueue.put so that network
-        clients and servers can be used interchangeably with asyncio queues
-        expecting a put method.
-
-        Args:
-            item (FifoEvent):
-                Event to send over the network connection.
-        """
-
-        await self.send(item)
-
-
-class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, SupportsFifoEventPut):
+class FifoEventQueueNetworkAsyncClient(FifoEventQueueConnectorAsyncClient):
     """
     Asyncio-based network client for sending and receiving FifoEvent objects over TCP.
 
@@ -485,14 +287,11 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
             Priority queue containing received events from the network, ready for
             application consumption.
 
-        _thread (threading.Thread):
-            Currently unused thread attribute (legacy).
-
         _task (asyncio.Task[None]):
             Background asyncio task that continuously receives events from the network
             and places them in the output queue.
 
-        _handler (FifoEventQueueNetworkAsyncHandlerBase | None):
+        _handler (FifoEventQueueConnectorAsyncHandlerBase | None):
             Handler used to intercept and process events. If None, events are
             queued and sent directly without additional processing. When provided,
             the handler can:
@@ -503,15 +302,14 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
     _reader: asyncio.StreamReader
     _writer: asyncio.StreamWriter
     _out_queue: asyncio.PriorityQueue[FifoEvent]
-    _thread: threading.Thread
     _task: asyncio.Task[None]
-    _handler: FifoEventQueueNetworkAsyncHandlerBase | None
+    _handler: FifoEventQueueConnectorAsyncHandlerBase | None
 
     def __init__(self,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter,
                  out_queue: asyncio.PriorityQueue[FifoEvent] | None,
-                 handler: FifoEventQueueNetworkAsyncHandlerBase | None = None):
+                 handler: FifoEventQueueConnectorAsyncHandlerBase | None = None):
         """
         Initialize a FifoEventQueueNetworkAsyncClient with existing connection streams.
 
@@ -525,7 +323,7 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
             out_queue (asyncio.PriorityQueue[FifoEvent] | None):
                 Optional priority queue for received events. If None, a new queue is created.
 
-            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+            handler (FifoEventQueueConnectorAsyncHandlerBase | None, optional):
                 Handler used to intercept and process events. If None, events are
                 queued and sent directly without additional processing. When provided,
                 the handler can:
@@ -533,18 +331,14 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
                 - process outgoing events before they are sent, and
                 - observe sent events after they have been successfully sent.
         """
-        self._reader = reader
-        self._writer = writer
-        self._out_queue = out_queue or asyncio.PriorityQueue()
-        self._handler = handler
-        self._task = asyncio.create_task(self._network_to_queue())
+        super().__init__(reader, writer, out_queue, handler)
 
     @classmethod
     async def connect(cls,
                       host: str,
                       port: int,
                       out_queue: asyncio.PriorityQueue[FifoEvent] | None = None,
-                      handler: FifoEventQueueNetworkAsyncHandlerBase | None = None,
+                      handler: FifoEventQueueConnectorAsyncHandlerBase | None = None,
                       *,
                       ssl_ctx: ssl.SSLContext | None = None,
                       server_hostname: str | None = None,
@@ -568,7 +362,7 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
             out_queue (asyncio.PriorityQueue[FifoEvent] | None, optional):
                 Optional priority queue for received events. If None, a new queue is created.
 
-            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+            handler (FifoEventQueueConnectorAsyncHandlerBase | None, optional):
                 Handler used to intercept and process events. If None, events are
                 queued and sent directly without additional processing. When provided,
                 the handler can:
@@ -644,37 +438,11 @@ class FifoEventQueueNetworkAsyncClient(_FifoEventQueueNetworkAsyncMixin, Support
 
         return cls(reader, writer, out_queue, handler)
 
-    async def join(self, timeout: float = 5.0):
-        """
-        Wait for the client to finish shutting down and clean up resources.
 
-        This method waits for the background network-to-queue task to finish, then
-        properly closes the network connection. It includes timeout protection to
-        prevent hanging during shutdown.
-
-        Args:
-            timeout (float, optional):
-                Maximum time in seconds to wait for the background task to finish.
-                Defaults to 5.0 seconds.
-
-        Raises:
-            No exceptions are raised; timeouts and errors are logged and handled gracefully.
-        """
-        # Wait for `_network_to_queue` task to finish, cancel on timeout
-        try:
-            await asyncio.wait_for(self._task, timeout=timeout)
-        except asyncio.TimeoutError:
-            logger.warning("[client] join() timed out after %.1fs; cancelling background task.",
-                           timeout)
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._task
-
-        # Close writer with a bounded wait
-        await _bounded_close_and_wait_closed_writer(self._writer, timeout=3.0, label="client")
-
-
-class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, SupportsFifoEventPut):
+class FifoEventQueueNetworkAsyncServer(
+    _FifoEventQueueConnectorAsyncMixin,
+    SupportsFifoEventPut,
+):
     """
     Asyncio-based network server for sending and receiving FifoEvent objects over TCP.
 
@@ -709,7 +477,7 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
             Background asyncio task that continuously receives events from the client
             and places them in the output queue.
 
-        _handler (FifoEventQueueNetworkAsyncHandlerBase | None):
+        _handler (FifoEventQueueConnectorAsyncHandlerBase | None):
             Handler used to intercept and process events. If None, events are
             queued and sent directly without additional processing. When provided,
             the handler can:
@@ -722,14 +490,14 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
     _server: asyncio.Server
     _out_queue: asyncio.PriorityQueue[FifoEvent]
     _task: asyncio.Task[None]
-    _handler: FifoEventQueueNetworkAsyncHandlerBase | None
+    _handler: FifoEventQueueConnectorAsyncHandlerBase | None
 
     def __init__(self,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter,
                  server: asyncio.Server,
                  out_queue: asyncio.PriorityQueue[FifoEvent] | None,
-                 handler: FifoEventQueueNetworkAsyncHandlerBase | None = None):
+                 handler: FifoEventQueueConnectorAsyncHandlerBase | None = None):
         """
         Initialize a FifoEventQueueNetworkAsyncServer with existing connection and server.
 
@@ -746,7 +514,7 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
             out_queue (asyncio.PriorityQueue[FifoEvent] | None):
                 Optional priority queue for received events. If None, a new queue is created.
 
-            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+            handler (FifoEventQueueConnectorAsyncHandlerBase | None, optional):
                 Handler used to intercept and process events. If None, events are
                 queued and sent directly without additional processing. When provided,
                 the handler can:
@@ -766,7 +534,7 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
                      host: str,
                      port: int,
                      out_queue: asyncio.PriorityQueue[FifoEvent] | None = None,
-                     handler: FifoEventQueueNetworkAsyncHandlerBase | None = None,
+                     handler: FifoEventQueueConnectorAsyncHandlerBase | None = None,
                      *,
                      ssl_ctx: ssl.SSLContext | None = None,
                      ensure_ssl_ctx: bool = False):
@@ -789,7 +557,7 @@ class FifoEventQueueNetworkAsyncServer(_FifoEventQueueNetworkAsyncMixin, Support
             out_queue (asyncio.PriorityQueue[FifoEvent] | None, optional):
                 Optional priority queue for received events. If None, a new queue is created.
 
-            handler (FifoEventQueueNetworkAsyncHandlerBase | None, optional):
+            handler (FifoEventQueueConnectorAsyncHandlerBase | None, optional):
                 Handler used to intercept and process events. If None, events are
                 queued and sent directly without additional processing. When provided,
                 the handler can:

--- a/fifo_dev_common/event/fifo_event_queue_serial.py
+++ b/fifo_dev_common/event/fifo_event_queue_serial.py
@@ -1,0 +1,105 @@
+"""
+Asyncio-based serial transport for `FifoEvent` objects using `serial_asyncio`.
+
+> **Requirements**
+> - Relies on the third-party `pyserial-asyncio` package (`serial_asyncio`).
+> - The serial adapter must present an asyncio-compatible interface exposed by `serial_asyncio`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fifo_dev_common.event.fifo_event import FifoEvent
+from fifo_dev_common.event.fifo_event_queue_connector import (
+    FifoEventQueueConnectorAsyncClient,
+)
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerBase,
+)
+from fifo_dev_common.logging.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class FifoEventQueueSerialAsyncClient(FifoEventQueueConnectorAsyncClient):
+    """
+    Asyncio-based serial client for sending and receiving `FifoEvent` objects.
+
+    This client mirrors the behaviour of the TCP client but targets serial links managed by
+    `serial_asyncio`. Outbound events are serialized and written to the serial stream as soon as
+    `send()` is called, while inbound events are deserialized in a background task and placed into
+    an asyncio priority queue for consumption by the application.
+
+    The client inherits connection lifecycle handling, handler hooks, and queue management from
+    `FifoEventQueueConnectorAsyncClient`. It adds a convenience `connect()` constructor tailored to
+    serial ports and emits explicit logging so operators are aware of the lack of transport-level
+    encryption/authentication on typical serial links.
+    """
+
+    @classmethod
+    async def connect(
+        cls,
+        port: str,
+        *,
+        baudrate: int = 115_200,
+        out_queue: asyncio.PriorityQueue[FifoEvent] | None = None,
+        handler: FifoEventQueueConnectorAsyncHandlerBase | None = None,
+        **serial_kwargs: Any,
+    ) -> "FifoEventQueueSerialAsyncClient":
+        """
+        Open an asyncio serial connection and create a serial client instance.
+
+        Args:
+            port (str):
+                Path or URL of the serial device (e.g., `/dev/ttyUSB0`, `COM3`, or a virtual port
+                understood by `serial_asyncio`).
+
+            baudrate (int, optional):
+                Baud rate used when opening the serial connection. Defaults to `115_200`.
+
+            out_queue (asyncio.PriorityQueue[FifoEvent] | None, optional):
+                Optional priority queue that receives inbound events. When `None`, a new queue is
+                created so the client remains self-contained.
+
+            handler (FifoEventQueueConnectorAsyncHandlerBase | None, optional):
+                Optional handler used to intercept incoming, outgoing, and sent events. The handler
+                API matches the TCP implementation and is invoked in the same situations.
+
+            **serial_kwargs:
+                Additional keyword arguments forwarded to
+                `serial_asyncio.open_serial_connection()` (e.g., `bytesize`, `parity`,
+                `stopbits`). The `url` and `baudrate` parameters are reserved by this helper and
+                must not be supplied here.
+
+        Returns:
+            FifoEventQueueSerialAsyncClient:
+                Newly constructed serial client that wraps the opened serial connection.
+
+        Raises:
+            serial.SerialException: If the serial connection cannot be opened.
+            ValueError: If invalid parameters are provided to the underlying serial implementation.
+        """
+
+        from serial_asyncio import open_serial_connection
+
+        if "url" in serial_kwargs or "baudrate" in serial_kwargs:
+            raise ValueError(
+                "serial_kwargs must not contain 'url' or 'baudrate'; use the dedicated "
+                "parameters instead."
+            )
+
+        logger.warning(
+            "[serial-client] Opening serial connection on %s with baudrate %s",
+            port,
+            baudrate,
+        )
+
+        reader, writer = await open_serial_connection(
+            url=port,
+            baudrate=baudrate,
+            **serial_kwargs,
+        )
+
+        return cls(reader, writer, out_queue, handler)

--- a/fifo_dev_common/process/utils.py
+++ b/fifo_dev_common/process/utils.py
@@ -765,7 +765,8 @@ class FifoProcessManager:
 
         _async_out (SupportsFifoEventPut):
             Object to receive outgoing events from the main process, such as an asyncio
-            priority queue or a `FifoEventQueueNetworkAsyncServer/Client`.
+            priority queue, a `FifoEventQueueConnectorAsyncClient`, or a
+            `FifoEventQueueNetworkAsyncServer`.
 
         _lock_cid (asyncio.Lock):
             Lock used to protect concurrent access to the `_received_cid` dictionary from multiple
@@ -811,7 +812,8 @@ class FifoProcessManager:
 
             async_out (SupportsFifoEventPut):
                 Object to receive outgoing events from the main process, such as an asyncio
-                priority queue or a `FifoEventQueueNetworkAsyncServer/Client`.
+                priority queue, a `FifoEventQueueConnectorAsyncClient`, or a
+                `FifoEventQueueNetworkAsyncServer`.
         """
         self._loop = loop
 

--- a/tests/test_fifo_event_cid_background_manager.py
+++ b/tests/test_fifo_event_cid_background_manager.py
@@ -15,8 +15,8 @@ from fifo_dev_common.event.fifo_event import (
     EErrorCode,
 )
 from fifo_dev_common.event.fifo_event_cid_outcome import FifoEventCIDOutcome
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
 )
 from fifo_dev_common.serialization.fifo_serialization import serializable
 
@@ -65,7 +65,7 @@ class DummyDoneSuccess(FifoEventResultWithCID):
 
 @pytest.mark.asyncio
 async def test_background_manager_success_and_failure():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
 
     outcomes: list[tuple[FifoEventCIDOutcome[FifoEvent, FifoEventResultWithCID], FifoEventWithCID]] = []
     called = asyncio.Event()
@@ -81,7 +81,7 @@ async def test_background_manager_success_and_failure():
 
     # Minimal transport that only triggers template auto-registration
     class _Transport:
-        def __init__(self, h: FifoEventQueueNetworkAsyncHandlerCID) -> None:
+        def __init__(self, h: FifoEventQueueConnectorAsyncHandlerCID) -> None:
             self.h = h
 
         async def put(self, item: FifoEvent) -> None:

--- a/tests/test_fifo_event_cid_handler_helpers.py
+++ b/tests/test_fifo_event_cid_handler_helpers.py
@@ -15,8 +15,8 @@ from fifo_dev_common.event.fifo_event import (
     EErrorCode,
 )
 from fifo_dev_common.event.fifo_event_cid_outcome import FifoEventCIDOutcome
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
 )
 from fifo_dev_common.serialization.fifo_serialization import serializable
 
@@ -124,7 +124,7 @@ class _DummyTransport:
     auto-registration on the send path.
     """
 
-    def __init__(self, handler: FifoEventQueueNetworkAsyncHandlerCID) -> None:
+    def __init__(self, handler: FifoEventQueueConnectorAsyncHandlerCID) -> None:
         self._handler = handler
 
     async def put(self, item: FifoEvent) -> None:  # SupportsFifoEventPut
@@ -133,7 +133,7 @@ class _DummyTransport:
 
 @pytest.mark.asyncio
 async def test_cid_request_manager_success_flow():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     handler.register_cid_template(DummyCID, [DummyAck, [DummyDoneSuccess, DummyDoneFailure]])
 
     transport = _DummyTransport(handler)
@@ -160,7 +160,7 @@ async def test_cid_request_manager_success_flow():
 
 @pytest.mark.asyncio
 async def test_cid_request_manager_failure_on_ack():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     handler.register_cid_template(DummyCID, [DummyAck, [DummyDoneSuccess, DummyDoneFailure]])
 
     transport = _DummyTransport(handler)
@@ -185,7 +185,7 @@ async def test_cid_request_manager_failure_on_ack():
 
 @pytest.mark.asyncio
 async def test_handler_timeout():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     handler.register_cid_template(DummyCID, [DummyAck, [DummyDoneSuccess, DummyDoneFailure]])
 
     transport = _DummyTransport(handler)
@@ -202,7 +202,7 @@ async def test_handler_timeout():
 
 @pytest.mark.asyncio
 async def test_send_in_background_success_calls_callback():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
 
     transport = _DummyTransport(handler)
 
@@ -242,7 +242,7 @@ async def test_send_in_background_success_calls_callback():
 
 @pytest.mark.asyncio
 async def test_send_in_background_failure_calls_callback():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
 
     transport = _DummyTransport(handler)
 
@@ -278,12 +278,12 @@ async def test_send_in_background_failure_calls_callback():
 async def test_send_in_background_logs_on_callback_exception(caplog: pytest.LogCaptureFixture):
     import logging
 
-    caplog.set_level(logging.ERROR, logger="fifo_dev_common.event.fifo_event_queue_network_handler")
+    caplog.set_level(logging.ERROR, logger="fifo_dev_common.event.fifo_event_queue_connector_handler")
 
     async def on_outcome_raises(_outcome: FifoEventCIDOutcome[FifoEvent, FifoEventResultWithCID], _req: FifoEventWithCID) -> None:
         raise RuntimeError("boom")
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     handler.register_cid_template(DummyCID, [DummyAck, [DummyDoneSuccess, DummyDoneFailure]], on_outcome=on_outcome_raises)
 
     transport = _DummyTransport(handler)

--- a/tests/test_fifo_event_cid_refresh_manager.py
+++ b/tests/test_fifo_event_cid_refresh_manager.py
@@ -18,8 +18,8 @@ from fifo_dev_common.event.fifo_event_cid_outcome import FifoEventCIDOutcome
 from fifo_dev_common.event.fifo_event_cid_request_manager import (
     FifoEventCIDRefreshManager,
 )
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
 )
 from fifo_dev_common.state.fifo_refreshable_value import FifoRefreshableValue, CacheState
 from fifo_dev_common.serialization.fifo_serialization import serializable
@@ -69,7 +69,7 @@ class Done(FifoEventResultWithCID):
 
 @pytest.mark.asyncio
 async def test_refresh_manager_updates_cache():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     mgr = FifoEventCIDRefreshManager(handler)
 
     cache: FifoRefreshableValue[int] = FifoRefreshableValue()
@@ -79,7 +79,7 @@ async def test_refresh_manager_updates_cache():
 
     # Minimal transport to trigger template auto-registration
     class _Transport:
-        def __init__(self, h: FifoEventQueueNetworkAsyncHandlerCID) -> None:
+        def __init__(self, h: FifoEventQueueConnectorAsyncHandlerCID) -> None:
             self.h = h
 
         async def put(self, item: FifoEvent) -> None:
@@ -135,7 +135,7 @@ async def test_refresh_manager_updates_cache():
 
 @pytest.mark.asyncio
 async def test_refresh_manager_optional_on_outcome_called_success_and_failure():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     mgr = FifoEventCIDRefreshManager(handler)
 
     cache: FifoRefreshableValue[int] = FifoRefreshableValue()
@@ -150,7 +150,7 @@ async def test_refresh_manager_optional_on_outcome_called_success_and_failure():
     mgr.register(Rq, [Ack, Done], cache, extract=lambda ev: ev.value, success_types=(Done,), on_done=on_done)  # type: ignore
 
     class _Transport:
-        def __init__(self, h: FifoEventQueueNetworkAsyncHandlerCID) -> None:
+        def __init__(self, h: FifoEventQueueConnectorAsyncHandlerCID) -> None:
             self.h = h
 
         async def put(self, item: FifoEvent) -> None:

--- a/tests/test_fifo_event_queue_network_async.py
+++ b/tests/test_fifo_event_queue_network_async.py
@@ -20,8 +20,11 @@ from fifo_dev_common.event.fifo_event_queue_network import (
     FifoEventQueueNetworkAsyncClient,
     FifoEventQueueNetworkAsyncServer,
 )
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_serial import (
+    FifoEventQueueSerialAsyncClient,
+)
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
 )
 from fifo_dev_common.serialization.fifo_serialization import serializable
 from fifo_dev_common.event.fifo_event_protocols import SendStatus
@@ -193,6 +196,35 @@ async def test_client_server_roundtrip(use_tls: bool, unused_tcp_port: int):
 
 
 @pytest.mark.asyncio
+async def test_serial_client_uses_connector_base(unused_tcp_port: int):
+    host = "127.0.0.1"
+    port = unused_tcp_port
+
+    server_task = asyncio.create_task(
+        FifoEventQueueNetworkAsyncServer.accept(host, port)
+    )
+    await asyncio.sleep(0.01)
+
+    reader, writer = await asyncio.open_connection(host, port)
+    client = FifoEventQueueSerialAsyncClient(reader, writer, None)
+    server = await server_task
+
+    await client.send(DummyEvent(value=1))
+    recv = await server._out_queue.get()
+    assert isinstance(recv, DummyEvent)
+    assert recv.value == 1
+
+    await server.send(DummyEvent(value=2))
+    recv = await client._out_queue.get()
+    assert isinstance(recv, DummyEvent)
+    assert recv.value == 2
+
+    await client.stop()
+    await server.stop()
+    await asyncio.gather(client.join(), server.join())
+
+
+@pytest.mark.asyncio
 async def test_ensure_ssl_ctx_without_context_raises(unused_tcp_port: int):
     host = "127.0.0.1"
     port = unused_tcp_port
@@ -212,7 +244,7 @@ async def test_cid_handler_consumes_event(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
@@ -252,7 +284,7 @@ async def test_cid_handler_on_send_callback_invoked(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
@@ -299,7 +331,7 @@ async def test_cid_handler_on_sent_callback_invoked(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
@@ -341,9 +373,9 @@ async def test_handler_logs_on_sent_callback_failure(caplog: pytest.LogCaptureFi
     import logging
 
     # Capture error logs from the handler module
-    caplog.set_level(logging.ERROR, logger="fifo_dev_common.event.fifo_event_queue_network_handler")
+    caplog.set_level(logging.ERROR, logger="fifo_dev_common.event.fifo_event_queue_connector_handler")
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
 
     async def on_sent_raises(_ev: FifoEvent) -> None:
         # Raise a whitelisted exception to trigger the error log path
@@ -377,9 +409,9 @@ async def test_handler_logs_on_callback_failure(caplog: pytest.LogCaptureFixture
     import logging
 
     # Capture error logs from the handler module
-    caplog.set_level(logging.ERROR, logger="fifo_dev_common.event.fifo_event_queue_network_handler")
+    caplog.set_level(logging.ERROR, logger="fifo_dev_common.event.fifo_event_queue_connector_handler")
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
 
     async def on_send_raises(_ev: FifoEvent) -> None:
         # Raise a whitelisted exception to trigger the error log path
@@ -416,7 +448,7 @@ async def test_cid_handler_chain_consumes_events(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 
@@ -465,7 +497,7 @@ async def test_cid_handler_chain_stops_on_failure(unused_tcp_port: int):
     )
     await asyncio.sleep(0.01)
 
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     client = await FifoEventQueueNetworkAsyncClient.connect(host, port, handler=handler)
     server = await server_task
 

--- a/tests/test_fifo_event_queue_network_listener.py
+++ b/tests/test_fifo_event_queue_network_listener.py
@@ -11,8 +11,8 @@ from fifo_dev_common.event.fifo_event import (
     FifoEventShutdown,
     FifoEventWithCID,
 )
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
 )
 from fifo_dev_common.serialization.fifo_serialization import serializable
 
@@ -51,7 +51,7 @@ class _DummyCID(FifoEventWithCID):
 
 @pytest.mark.asyncio
 async def test_incoming_listener_fires_for_non_cid():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     evt = asyncio.Event()
     seen: list[FifoEvent] = []
 
@@ -73,7 +73,7 @@ async def test_incoming_listener_fires_for_non_cid():
 
 @pytest.mark.asyncio
 async def test_incoming_listener_receives_shutdown():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     evt = asyncio.Event()
 
     async def on_shutdown(_ev: FifoEvent) -> None:
@@ -89,7 +89,7 @@ async def test_incoming_listener_receives_shutdown():
 
 @pytest.mark.asyncio
 async def test_incoming_listener_does_not_fire_for_cid():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     evt = asyncio.Event()
 
     async def on_any(_ev: FifoEvent) -> None:
@@ -108,7 +108,7 @@ async def test_incoming_listener_does_not_fire_for_cid():
 
 @pytest.mark.asyncio
 async def test_incoming_listener_consume_suppresses_propagation():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     evt_called = asyncio.Event()
 
     async def on_event(_ev: FifoEvent) -> None:
@@ -128,7 +128,7 @@ async def test_incoming_listener_consume_suppresses_propagation():
 
 @pytest.mark.asyncio
 async def test_multiple_listeners_with_one_consumer_both_called_but_consumed():
-    handler = FifoEventQueueNetworkAsyncHandlerCID()
+    handler = FifoEventQueueConnectorAsyncHandlerCID()
     called = [False, False]
 
     async def l1(_ev: FifoEvent) -> None:

--- a/tests/test_fifo_event_queue_network_registration_guards.py
+++ b/tests/test_fifo_event_queue_network_registration_guards.py
@@ -12,8 +12,8 @@ from fifo_dev_common.event.fifo_event import (
     FifoEventShutdown,
     EErrorCode,
 )
-from fifo_dev_common.event.fifo_event_queue_network_handler import (
-    FifoEventQueueNetworkAsyncHandlerCID,
+from fifo_dev_common.event.fifo_event_queue_connector_handler import (
+    FifoEventQueueConnectorAsyncHandlerCID,
 )
 from fifo_dev_common.serialization.fifo_serialization import serializable
 
@@ -44,7 +44,7 @@ class _NonCID(FifoEvent):
 
 @pytest.mark.asyncio
 async def test_duplicate_cid_template_registration_raises():
-    h = FifoEventQueueNetworkAsyncHandlerCID()
+    h = FifoEventQueueConnectorAsyncHandlerCID()
 
     h.register_cid_template(_Req, [_Ack])
     with pytest.raises(ValueError):
@@ -57,7 +57,7 @@ async def test_duplicate_cid_template_registration_raises():
 
 @pytest.mark.asyncio
 async def test_incoming_listener_guards_and_dedup():
-    h = FifoEventQueueNetworkAsyncHandlerCID()
+    h = FifoEventQueueConnectorAsyncHandlerCID()
 
     async def cb(_e: FifoEvent):
         pass


### PR DESCRIPTION
## Summary
- Extract the shared asyncio stream handling into a new `fifo_event_queue_connector` module, providing the `_FifoEventQueueConnectorAsyncMixin`, `FifoEventQueueConnectorAsyncClient`, and bounded writer shutdown helper while renaming the handler hierarchy to the connector terminology and updating the CID refresh manager to import the new types.

- Rework the TCP client to inherit from the connector base and introduce `FifoEventQueueSerialAsyncClient` so serial transports can share the same lifecycle and handler hooks, accompanied by `README` sections describing the connector, network, and serial modules.

- Expand the asyncio tests to import the connector abstractions, exercise the serial client, and verify the renamed handler's callbacks across send and outcome flows.

## Testing
- pytest