### PR TITLE
Add bool support to numpy serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,8 @@ Provides a lightweight, efficient binary serialization framework for Python data
 | `?x`       | **Optional primitive**               | 1-byte presence flag + `x` if present                                  | `x` must be one of: `b B h H i I l L q Q e f d y`                     |
 | `T<xx...>` | **Fixed-length tuple of primitives** | Each element serialized consecutively (no prefix)                    | Each `x` must be one of: `b B h H i I l L q Q e f d y`                  |
 | `?T<xx...>` | **Optional fixed-length tuple of primitives** | 1-byte presence flag + serialized elements if present | Each `x` must be one of: `b B h H i I l L q Q e f d y` |
-| `[np:x]`   | **NumPy array**                      | 1-byte ndim + N×4-byte shape + raw data buffer                         | `x` must be NumPy dtype: `u8`, `u16`, `u32`, `i8`, `i16`, `i32`, `f32`, `f64` |
-| `[np:x:shape]` | **Fixed-shape NumPy array**       | Raw data buffer only; shape is provided in format string                | `shape` is comma-separated dims, e.g. `[np:f32:2,3]` |
+| `[np:x]`   | **NumPy array**                      | 1-byte ndim + N×4-byte shape + raw data buffer (booleans packed as bits)| `x` must be NumPy dtype: `u8`, `u16`, `u32`, `bool`, `i8`, `i16`, `i32`, `f32`, `f64` |
+| `[np:x:shape]` | **Fixed-shape NumPy array**       | Raw data buffer only; shape is provided in format string (booleans packed)| `shape` is comma-separated dims, e.g. `[np:f32:2,3]` |
 | `S`        | **Variable-length UTF-8 string**     | 4-byte length prefix + UTF-8 encoded bytes                             | -                                                                     |
 | `S[x]`     | **Fixed-length UTF-8 string**        | UTF-8 encoded, space-padded or truncated to `x` bytes (UTF-8 safe)     | -                                                                     |
 | `?S`       | **Optional variable-length UTF-8 string** | 1-byte presence flag + 4-byte length + UTF-8 encoded bytes            | -

--- a/fifo_dev_common/serialization/fifo_serialization.py
+++ b/fifo_dev_common/serialization/fifo_serialization.py
@@ -14,6 +14,7 @@ _NUMPY_DTYPES: dict[str, np.dtype[Any]] = {
     "u8": np.dtype(np.uint8),
     "u16": np.dtype(np.uint16),
     "u32": np.dtype(np.uint32),
+    "bool": np.dtype(np.bool_),
     "i8": np.dtype(np.int8),
     "i16": np.dtype(np.int16),
     "i32": np.dtype(np.int32),
@@ -150,13 +151,14 @@ def compile_field(field: Field[Any]) -> FieldSpecCompiled:
             Example: '[f]' means a variable-length array of floats.
 
       - NumPy arrays of fixed dtype:
-          - '[np:x]' where x is one of 'u8', 'u16', 'u32', 'i8', 'i16', 'i32',
-            'f32', 'f64'. The dtype must be fixed for the field.
-            Supports arrays of arbitrary dimension.
-          - '[np:x:shape]' where 'shape' is a comma-separated list of
-            integers specifying the fixed array shape (e.g.,
-            '[np:i32:64]' for a vector of length 64, '[np:f32:2,3]' for a
-            2x3 array). The array's shape is omitted from the serialized
+          - '[np:x]' where x is one of 'u8', 'u16', 'u32', 'bool', 'i8', 'i16',
+            'i32', 'f32', 'f64'. The dtype must be fixed for the field.
+            Supports arrays of arbitrary dimension. Booleans are packed as bits
+            into bytes to minimize space.
+      - '[np:x:shape]' where 'shape' is a comma-separated list of
+        integers specifying the fixed array shape (e.g.,
+        '[np:i32:64]' for a vector of length 64, '[np:f32:2,3]' for a
+        2x3 array). The array's shape is omitted from the serialized
             data, reducing overhead when the shape is known.
 
       - Optional values (nullable) of basic types:
@@ -1354,6 +1356,7 @@ class FieldSpecCompiledFixedNumpyArray(FieldSpecCompiled):
     dtype: np.dtype[Any]
     shape: tuple[int, ...]
     _byte_len: int
+    _element_count: int
 
     def __init__(self, name: str, dtype: np.dtype[Any], shape: tuple[int, ...]):
         """
@@ -1375,7 +1378,8 @@ class FieldSpecCompiledFixedNumpyArray(FieldSpecCompiled):
         count = 1
         for dim in self.shape:
             count *= dim
-        self._byte_len = count * self.dtype.itemsize
+        self._element_count = count
+        self._byte_len = (count + 7) // 8 if self.dtype == np.bool_ else count * self.dtype.itemsize
 
     def serialize_to_bytes(self, class_obj: Any, buffer: bytearray, idx: int) -> int:
         """
@@ -1404,7 +1408,10 @@ class FieldSpecCompiledFixedNumpyArray(FieldSpecCompiled):
             raise ValueError("NDArray dtype mismatch")
         if arr.shape != self.shape:
             raise ValueError("NDArray shape mismatch")
-        data = arr.tobytes(order="C")
+        if self.dtype == np.bool_:
+            data = np.packbits(arr.reshape(-1, order="C"), bitorder="little").tobytes()
+        else:
+            data = arr.tobytes(order="C")
         buffer[idx:idx + self._byte_len] = data
         return idx + self._byte_len
 
@@ -1424,9 +1431,14 @@ class FieldSpecCompiledFixedNumpyArray(FieldSpecCompiled):
                 - The deserialized NumPy array.
                 - The updated buffer index after reading.
         """
-        count = self._byte_len // self.dtype.itemsize
-        arr = np.frombuffer(buffer, dtype=self.dtype, count=count, offset=idx).reshape(self.shape)
-        arr = arr.copy()  # Defensive copy (frombuffer is always read-only)
+        count = self._element_count
+        if self.dtype == np.bool_:
+            packed = np.frombuffer(buffer, dtype=np.uint8, count=self._byte_len, offset=idx)
+            unpacked = np.unpackbits(packed, count=count, bitorder="little")
+            arr = unpacked.astype(np.bool_, copy=False).reshape(self.shape)
+        else:
+            arr = np.frombuffer(buffer, dtype=self.dtype, count=count, offset=idx).reshape(self.shape)
+            arr = arr.copy()  # Defensive copy (frombuffer is always read-only)
         idx += self._byte_len
         return arr, idx
 
@@ -1516,7 +1528,10 @@ class FieldSpecCompiledNumpyArray(FieldSpecCompiled):
         idx += 1
         struct.pack_into("<" + "I" * ndim, buffer, idx, *arr.shape)
         idx += 4 * ndim
-        data = arr.tobytes(order="C")
+        if self.dtype == np.bool_:
+            data = np.packbits(arr.reshape(-1, order="C"), bitorder="little").tobytes()
+        else:
+            data = arr.tobytes(order="C")
         buffer[idx:idx + len(data)] = data
         return idx + len(data)
 
@@ -1543,9 +1558,15 @@ class FieldSpecCompiledNumpyArray(FieldSpecCompiled):
         count = 1
         for dim in shape:
             count *= dim
-        byte_len = count * self.dtype.itemsize
-        arr = np.frombuffer(buffer, dtype=self.dtype, count=count, offset=idx).reshape(shape)
-        arr = arr.copy()  # Defensive copy (frombuffer is always read-only)
+        if self.dtype == np.bool_:
+            byte_len = (count + 7) // 8
+            packed = np.frombuffer(buffer, dtype=np.uint8, count=byte_len, offset=idx)
+            unpacked = np.unpackbits(packed, count=count, bitorder="little")
+            arr = unpacked.astype(np.bool_, copy=False).reshape(shape)
+        else:
+            byte_len = count * self.dtype.itemsize
+            arr = np.frombuffer(buffer, dtype=self.dtype, count=count, offset=idx).reshape(shape)
+            arr = arr.copy()  # Defensive copy (frombuffer is always read-only)
         idx += byte_len
         return arr, idx
 
@@ -1562,6 +1583,8 @@ class FieldSpecCompiledNumpyArray(FieldSpecCompiled):
                 The total byte size for serialization.
         """
         arr: NDArray[Any] = getattr(class_obj, self.name)
+        if self.dtype == np.bool_:
+            return 1 + 4 * arr.ndim + (arr.size + 7) // 8
         return 1 + 4 * arr.ndim + arr.nbytes
 
 

--- a/tests/test_fifo_serialization.py
+++ b/tests/test_fifo_serialization.py
@@ -520,6 +520,12 @@ class TestNumpy1D(FifoSerializable):
 
 @serializable
 @dataclass
+class TestNumpyBool(FifoSerializable):
+    arr: NDArray[np.bool_] = field(metadata={"format": "[np:bool]"})
+
+
+@serializable
+@dataclass
 class TestNumpy2D(FifoSerializable):
     arr: NDArray[np.float32] = field(metadata={"format": "[np:f32]"})
 
@@ -548,19 +554,28 @@ class TestNumpyFixedMatrix(FifoSerializable):
     arr: NDArray[np.int8] = field(metadata={"format": "[np:i8:3,3]"})
 
 
+@serializable
+@dataclass
+class TestNumpyFixedBool(FifoSerializable):
+    arr: NDArray[np.bool_] = field(metadata={"format": "[np:bool:2,2]"})
+
+
 def test_numpy_arrays_roundtrip() -> None:
     a1 = np.arange(10, dtype=np.uint8)
     a2 = np.arange(6, dtype=np.float32).reshape(2, 3)
     a3 = np.arange(24, dtype=np.int16).reshape(2, 3, 4)
+    a4 = np.array([True, False, True, True, False, False, True, False, True], dtype=np.bool_).reshape(3, 3)
 
     o1 = TestNumpy1D(a1)
     o2 = TestNumpy2D(a2)
     o3 = TestNumpy3D(a3)
+    o4 = TestNumpyBool(a4)
 
     lst: list[tuple[FifoSerializable, NDArray[Any], Type[FifoSerializable]]] = [
         (o1, a1, TestNumpy1D),
         (o2, a2, TestNumpy2D),
         (o3, a3, TestNumpy3D),
+        (o4, a4, TestNumpyBool),
     ]
 
     for obj, arr, cls in lst:
@@ -576,15 +591,18 @@ def test_numpy_fixed_arrays_roundtrip() -> None:
     v1 = np.arange(64, dtype=np.int32)
     v2 = np.arange(6, dtype=np.float32).reshape(2, 3)
     v3 = np.arange(9, dtype=np.int8).reshape(3, 3)
+    v4 = np.array([[True, False], [False, True]], dtype=np.bool_)
 
     o1 = TestNumpyFixed1D(v1)
     o2 = TestNumpyFixed2D(v2)
     o3 = TestNumpyFixedMatrix(v3)
+    o4 = TestNumpyFixedBool(v4)
 
     lst: list[tuple[FifoSerializable, NDArray[Any], Type[FifoSerializable]]] = [
         (o1, v1, TestNumpyFixed1D),
         (o2, v2, TestNumpyFixed2D),
         (o3, v3, TestNumpyFixedMatrix),
+        (o4, v4, TestNumpyFixedBool),
     ]
 
     for obj, arr, cls in lst:


### PR DESCRIPTION
## Summary
- add boolean dtype support for numpy array serialization and bit-packed encoding
- update documentation and numpy serialization tests to cover boolean arrays

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6bfc6ed4832d8d2655b3ea612c81)